### PR TITLE
fix: semantic html for formula cannot be rendered as expect

### DIFF
--- a/packages/quill/src/formats/formula.ts
+++ b/packages/quill/src/formats/formula.ts
@@ -28,7 +28,7 @@ class Formula extends Embed {
 
   html() {
     const { formula } = this.value();
-    return `<span>${formula}</span>`;
+    return `<span class="${Formula.className}" data-value="${formula}">${formula}</span>`;
   }
 }
 


### PR DESCRIPTION
when apply semantic html for formula as content of editor, just print formula text.

**Steps for Reproduction**

1. create html with `<div id="editor"></div>` and editor creation related code, then load the page
2. enter a formula in editor, for exampe: `x^2+y^2=1`
3. take html string from `getSemanticHTML()`, then paste into html file, as the content of `div#editor`, then refresh browser

**Expected behavior:**

the formula should be pretty rendered

**Actual behavior:**

just print the text what we entered

**Platforms:**

Firefox

**Version:**

Quill 2.0.2
