### PR TITLE
fix: recognize <th> as a new line

### DIFF
--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -348,6 +348,7 @@ function isLine(node: Node, scroll: ScrollBlot) {
     'pre',
     'section',
     'table',
+    'th',
     'td',
     'tr',
     'ul',


### PR DESCRIPTION
Make clipboard support TH element  
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th