### PR TITLE
Add quill-specific-generic class to generated buttons #4281

### DIFF
--- a/packages/quill/src/modules/toolbar.ts
+++ b/packages/quill/src/modules/toolbar.ts
@@ -188,6 +188,7 @@ function addButton(container: HTMLElement, format: string, value?: string) {
   const input = document.createElement('button');
   input.setAttribute('type', 'button');
   input.classList.add(`ql-${format}`);
+  input.classList.add(`ql-button`);
   input.setAttribute('aria-pressed', 'false');
   if (value != null) {
     input.value = value;


### PR DESCRIPTION
This is the first step to fix #4281 . It has no backward compatibility break.

The second one is in the themes and may be a problem for the custom CSS people may use combined with the snow theme, this is why this PR does not contain this change. (even though it's not a break by itself!)
