### PR TITLE
Update Image to support title attribute

### DIFF
--- a/packages/quill/src/formats/image.ts
+++ b/packages/quill/src/formats/image.ts
@@ -1,7 +1,7 @@
 import { EmbedBlot } from 'parchment';
 import { sanitize } from './link.js';
 
-const ATTRIBUTES = ['alt', 'height', 'width'];
+const ATTRIBUTES = ['alt', 'title', 'height', 'width'];
 
 class Image extends EmbedBlot {
   static blotName = 'image';


### PR DESCRIPTION
Support for the title attribute on image tags is missing. 

`alt` is there but does not serve the same purpose, alt being for SEO and screen readers, providing a full description of the image contents and a text description in the case of a broken link.

`title` is a more readable attribute for tooltips and captions.

This PR adds `title` to the list of attributes supported by the `image` format.