### PR TITLE
Handle consecutive spaces when copying and pasting

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -370,7 +370,8 @@ function convertHTML(
     return blot.html(index, length);
   }
   if (blot instanceof TextBlot) {
-    return escapeText(blot.value().slice(index, index + length));
+    const escapedText = escapeText(blot.value().slice(index, index + length));
+    return escapedText.replace(/\s/g, '&nbsp;');
   }
   if (blot instanceof ParentBlot) {
     // TODO fix API

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -371,7 +371,7 @@ function convertHTML(
   }
   if (blot instanceof TextBlot) {
     const escapedText = escapeText(blot.value().slice(index, index + length));
-    return escapedText.replace(/\s/g, '&nbsp;');
+    return escapedText.replaceAll(' ', '&nbsp;');
   }
   if (blot instanceof ParentBlot) {
     // TODO fix API

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -629,7 +629,7 @@ const SPACE_EXCLUDE_NBSP = `[^\\S${NBSP}]`;
 
 function matchText(node: HTMLElement, delta: Delta, scroll: ScrollBlot) {
   // @ts-expect-error
-  let text = node.data;
+  let text = node.data as string;
   // Word represents empty line with <o:p>&nbsp;</o:p>
   if (node.parentElement?.tagName === 'O:P') {
     return delta.insert(text.trim());

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -244,6 +244,12 @@ describe('Clipboard', () => {
       expect(delta).toEqual(new Delta().insert('0\n1 2  3  4\n5 6  7 8'));
     });
 
+    test('multiple whitespaces', () => {
+      const html = '<div>1   2    3</div>';
+      const delta = createClipboard().convert({ html });
+      expect(delta).toEqual(new Delta().insert('1 2 3'));
+    });
+
     test('inline whitespace', () => {
       const html = '<p>0 <strong>1</strong> 2</p>';
       const delta = createClipboard().convert({ html });
@@ -256,19 +262,23 @@ describe('Clipboard', () => {
       const html = '<span>0&nbsp;<strong>1</strong>&nbsp;2</span>';
       const delta = createClipboard().convert({ html });
       expect(delta).toEqual(
-        new Delta()
-          .insert('0\u00a0')
-          .insert('1', { bold: true })
-          .insert('\u00a02'),
+        new Delta().insert('0 ').insert('1', { bold: true }).insert(' 2'),
       );
     });
 
     test('consecutive intentional whitespace', () => {
       const html = '<strong>&nbsp;&nbsp;1&nbsp;&nbsp;</strong>';
       const delta = createClipboard().convert({ html });
-      expect(delta).toEqual(
-        new Delta().insert('\u00a0\u00a01\u00a0\u00a0', { bold: true }),
-      );
+      expect(delta).toEqual(new Delta().insert('  1  ', { bold: true }));
+    });
+
+    test('intentional whitespace at line start/end', () => {
+      expect(
+        createClipboard().convert({ html: '<p>0 &nbsp;</p><p>&nbsp; 2</p>' }),
+      ).toEqual(new Delta().insert('0  \n  2'));
+      expect(
+        createClipboard().convert({ html: '<p>0&nbsp; </p><p> &nbsp;2</p>' }),
+      ).toEqual(new Delta().insert('0 \n 2'));
     });
 
     test('newlines between inline elements', () => {

--- a/packages/quill/tsconfig.json
+++ b/packages/quill/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "allowSyntheticDefaultImports": true,
-    "target": "ES2020",
+    "target": "ES2021",
     "sourceMap": true,
     "resolveJsonModule": true,
     "declaration": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
   },
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "target": "ES2020",
+    "target": "ES2021",
     "sourceMap": true,
     "declaration": true,
     "module": "ES2020",


### PR DESCRIPTION
Replaces #4319

## Test Plan

1. Paste content contains multiple regular spaces into Quill editor, make sure they are collapsed correctly unless they are inside a `<pre>`.
1. Paste content contains multiple &nbsp; spaces into Quill editor, make sure they are not collapsed and they are converted into regular spaces.
2. Copy content that contains multiple spaces from Quill editor, make sure they are copied as non-breaking spaces.
3. Make sure the bug mentioned in https://github.com/slab/quill/pull/4319 is not reproducible anymore.