### PR TITLE
Fix embed selection issues

### DIFF
--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -281,11 +281,11 @@ class Selection {
       const blot = this.scroll.find(node, true);
       // @ts-expect-error Fix me later
       const index = blot.offset(this.scroll);
-      if (offset === 0) {
-        return index;
-      }
       if (blot instanceof LeafBlot) {
         return index + blot.index(node, offset);
+      }
+      if (offset === 0) {
+        return index;
       }
       // @ts-expect-error Fix me later
       return index + blot.length();

--- a/packages/quill/test/unit/core/selection.spec.ts
+++ b/packages/quill/test/unit/core/selection.spec.ts
@@ -12,6 +12,18 @@ import Strike from '../../../src/formats/strike.js';
 import { ColorStyle } from '../../../src/formats/color.js';
 import { BackgroundStyle } from '../../../src/formats/background.js';
 import { SizeClass } from '../../../src/formats/size.js';
+import Embed from '../../../src/blots/embed';
+import Scroll from '../../../src/blots/scroll';
+
+class TestEmbed extends Embed {
+  static blotName = 'TestEmbed';
+  static tagName = 'span';
+  static className = 'test-embed-blot';
+
+  constructor(scroll: Scroll, node: Node) {
+    super(scroll, node);
+  }
+}
 
 const createSelection = (html: string, container = document.body) => {
   const scroll = createScroll(
@@ -26,6 +38,7 @@ const createSelection = (html: string, container = document.body) => {
       ColorStyle,
       BackgroundStyle,
       SizeClass,
+      TestEmbed
     ]),
     container,
   );
@@ -225,6 +238,51 @@ describe('Selection', () => {
       textarea.select();
       const [range] = selection.getRange();
       expect(range).toEqual(null);
+    });
+
+    test('between inner sides of embed guards', () => {
+      const selection = createSelection(
+        `<p><span class="test-embed-blot"></span></p>`,
+      );
+      const leftGuard = selection.root.querySelector('.test-embed-blot')?.firstChild as Node;
+      const rightGuard = selection.root.querySelector('.test-embed-blot')?.lastChild as Node;
+      selection.setNativeRange(
+        leftGuard,
+        1,
+        rightGuard,
+        0,
+      );
+      const [range] = selection.getRange();
+      expect(range?.index).toEqual(0);
+      expect(range?.length).toEqual(1);
+    });
+
+    test('on inner side of embed end guard', () => {
+      const selection = createSelection(
+        `<p><span class="test-embed-blot"></span></p>`,
+      );
+      const rightGuard = selection.root.querySelector('.test-embed-blot')?.lastChild as Node;
+      selection.setNativeRange(
+        rightGuard,
+        0
+      );
+      const [range] = selection.getRange();
+      expect(range?.index).toEqual(1);
+      expect(range?.length).toEqual(0);
+    });
+
+    test('on inner side of embed start guard', () => {
+      const selection = createSelection(
+        `<p><span class="test-embed-blot"></span></p>`,
+      );
+      const leftGuard = selection.root.querySelector('.test-embed-blot')?.firstChild as Node;
+      selection.setNativeRange(
+        leftGuard,
+        1
+      );
+      const [range] = selection.getRange();
+      expect(range?.index).toEqual(0);
+      expect(range?.length).toEqual(0);
     });
   });
 


### PR DESCRIPTION
This update fixes an issue when the selection ends on or the cursor is at the innermost part (offset 0) of the right guard of an embed.

<left guard><embed content node>|cursor|<right guard>

Two common cases that this solves:
- selecting from the left guard to the right guard offset 0 will not select the embed
- when having the cursor at right guard offset 0 and then hitting enter will insert the line break before the embed

The implementation suggestion is to let the leaf blot (as embed inherits from leaf) calculate the index offset even if it is at offset 0. Looking at the base implementation for the leaf and text blots is seems safe to change the order here. Another option is to add an extra check specifically for embed blots but seems redundant if I am not missing something.