### PR TITLE
Update api.mdx: on "editor-changes" docs fix.

### DIFF
--- a/packages/website/content/docs/api.mdx
+++ b/packages/website/content/docs/api.mdx
@@ -685,7 +685,7 @@ quill.on('editor-change', (eventName, ...args) => {
   if (eventName === 'text-change') {
     // args[0] will be delta
   } else if (eventName === 'selection-change') {
-    // args[0] will be old range
+    // args[0] will be last range
   }
 });
 ```


### PR DESCRIPTION
.on("editor-change') when eventName 'selection-change' args[0] is last range and args[1] is old range.