### PR TITLE
fix: can not delete embed blots on android

### DIFF
--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -281,11 +281,11 @@ class Selection {
       const blot = this.scroll.find(node, true);
       // @ts-expect-error Fix me later
       const index = blot.offset(this.scroll);
-      if (offset === 0) {
-        return index;
-      }
       if (blot instanceof LeafBlot) {
         return index + blot.index(node, offset);
+      }
+      if (offset === 0) {
+        return index;
       }
       // @ts-expect-error Fix me later
       return index + blot.length();


### PR DESCRIPTION
fix https://github.com/slab/quill/issues/1985

### the reason of this issue

the cursor focus between the contentNode of the embed and the rightGuard of the embed which is a zero-width space

in this case, the native selection range is like 
```
{
 start:{
   node: rightGuard,
   offset: 0,
 }
}
```

until now, everything is fine

but when quill normalize this range, it goes the wrong way, because `offset` is 0. 

![image](https://github.com/user-attachments/assets/56cb5548-682e-4ea3-a21d-c0fbc1e13e6f)

the final range we get is the position before our embed

so when you backspace

you can't delete the embed

you just delete the previous sibling