### PR TITLE
Change data-list attribute to ql-list-item classes

### DIFF
--- a/packages/quill/src/assets/core.styl
+++ b/packages/quill/src/assets/core.styl
@@ -22,8 +22,8 @@ resets(arr)
     visibility: hidden
 
 .ql-container:not(.ql-disabled)
-  li[data-list=checked],
-  li[data-list=unchecked]
+  li.ql-list-item-checked,
+  li.ql-list-item-unchecked
     > .ql-ui
       cursor: pointer
 
@@ -81,35 +81,35 @@ resets(arr)
       white-space: nowrap
       width: LIST_STYLE_WIDTH
 
-  li[data-list=checked],
-  li[data-list=unchecked]
+  li.ql-list-item-checked,
+  li.ql-list-item-unchecked
     > .ql-ui
       color: #777
 
-  li[data-list=bullet] > .ql-ui:before
+  li.ql-list-item-bullet > .ql-ui:before
     content: '\2022'
-  li[data-list=checked] > .ql-ui:before
+  li.ql-list-item-checked > .ql-ui:before
     content: '\2611'
-  li[data-list=unchecked] > .ql-ui:before
+  li.ql-list-item-unchecked > .ql-ui:before
     content: '\2610'
 
-  li[data-list]
+  li.ql-list-item
     @supports (counter-set: none)
       counter-set: resets(1..MAX_INDENT)
     @supports not (counter-set: none)
       counter-reset: resets(1..MAX_INDENT)
 
-  li[data-list=ordered]
+  li.ql-list-item-ordered
     counter-increment: list-0
     > .ql-ui:before
       content: unquote('counter(list-0, ' + LIST_STYLE[0] + ')') '. '
   for num in (1..MAX_INDENT)
-    li[data-list=ordered].ql-indent-{num}
+    li.ql-list-item-ordered.ql-indent-{num}
       counter-increment: unquote('list-' + num)
       > .ql-ui:before
         content: unquote('counter(list-' + num + ', ' + LIST_STYLE[num%3] + ')') '. '
     if (num < MAX_INDENT)
-      li[data-list].ql-indent-{num}
+      li.ql-list-item.ql-indent-{num}
         @supports (counter-set: none)
           counter-set: resets((num+1)..MAX_INDENT)
         @supports not (counter-set: none)

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -439,9 +439,9 @@ function getListType(type: string | undefined) {
   const tag = type === 'ordered' ? 'ol' : 'ul';
   switch (type) {
     case 'checked':
-      return [tag, ' data-list="checked"'];
+      return [tag, ' class="ql-list-item ql-list-item-checked"'];
     case 'unchecked':
-      return [tag, ' data-list="unchecked"'];
+      return [tag, ' class="ql-list-item ql-list-item-unchecked"'];
     default:
       return [tag, ''];
   }

--- a/packages/quill/src/formats/list.ts
+++ b/packages/quill/src/formats/list.ts
@@ -10,12 +10,20 @@ ListContainer.tagName = 'OL';
 class ListItem extends Block {
   static create(value: string) {
     const node = super.create() as HTMLElement;
-    node.setAttribute('data-list', value);
+    node.classList.add('ql-list-item');
+    if (value) {
+      node.classList.add(`ql-list-item-${value}`);
+    }
     return node;
   }
 
   static formats(domNode: HTMLElement) {
-    return domNode.getAttribute('data-list') || undefined;
+    return (
+      domNode.className
+        .split(' ')
+        .find((c) => c.startsWith('ql-list-item-'))
+        ?.split('ql-list-item-')[1] || undefined
+    );
   }
 
   static register() {
@@ -43,7 +51,11 @@ class ListItem extends Block {
 
   format(name: string, value: string) {
     if (name === this.statics.blotName && value) {
-      this.domNode.setAttribute('data-list', value);
+      const currentFormat = ListItem.formats(this.domNode);
+      if (currentFormat) {
+        this.domNode.classList.remove(`ql-list-item-${currentFormat}`);
+      }
+      this.domNode.classList.add(`ql-list-item-${value}`);
     } else {
       super.format(name, value);
     }

--- a/packages/quill/src/modules/normalizeExternalHTML/normalizers/msWord.ts
+++ b/packages/quill/src/modules/normalizeExternalHTML/normalizers/msWord.ts
@@ -68,9 +68,10 @@ const normalizeListItem = (doc: Document) => {
     const ul = document.createElement('ul');
     childListItems.forEach((listItem) => {
       const li = document.createElement('li');
-      li.setAttribute('data-list', listItem.type);
+      li.classList.add(`ql-list-item`);
+      li.classList.add(`ql-list-item-${listItem.type}`);
       if (listItem.indent > 1) {
-        li.setAttribute('class', `ql-indent-${listItem.indent - 1}`);
+        li.classList.add(`ql-indent-${listItem.indent - 1}`);
       }
       li.innerHTML = listItem.element.innerHTML;
       ul.appendChild(li);

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -284,7 +284,7 @@ describe('Editor', () => {
 
     test('partial line', () => {
       const editor = createEditor(
-        '<h1>01</h1><ol><li data-list="ordered">34</li></ol>',
+        '<h1>01</h1><ol><li class="ql-list-item ql-list-item-ordered">34</li></ol>',
       );
       editor.removeFormat(1, 3);
       expect(editor.scroll.domNode).toEqualHTML('<p>01</p><p>34</p>');
@@ -301,7 +301,7 @@ describe('Editor', () => {
         `
         <h1>01<img src="/assets/favicon.png">3</h1>
         <ol>
-          <li data-list="ordered">5<strong>6<em>78</em>9</strong>0</li>
+          <li class="ql-list-item ql-list-item-ordered">5<strong>6<em>78</em>9</strong>0</li>
         </ol>
       `,
       );
@@ -316,8 +316,8 @@ describe('Editor', () => {
       const editor = createEditor(
         `
         <ol>
-          <li data-list="ordered">0123</li>
-          <li data-list="ordered">5678</li>
+          <li class="ql-list-item ql-list-item-ordered">0123</li>
+          <li class="ql-list-item ql-list-item-ordered">5678</li>
         </ol>
       `,
       );
@@ -841,7 +841,9 @@ describe('Editor', () => {
     });
 
     test('prepend to list item', () => {
-      const editor = createEditor('<ol><li data-list="bullet">2</li></ol>');
+      const editor = createEditor(
+        '<ol><li class="ql-list-item ql-list-item-bullet">2</li></ol>',
+      );
       editor.insertContents(0, new Delta().insert('1'));
       expect(editor.getDelta().ops).toEqual([
         { insert: '12' },
@@ -1054,7 +1056,9 @@ describe('Editor', () => {
     });
 
     test('inserts multiple lines to a container', () => {
-      const editor = createEditor(`<ol><li data-list="ordered"></li></ol>`);
+      const editor = createEditor(
+        `<ol><li class="ql-list-item ql-list-item-ordered"></li></ol>`,
+      );
       editor.insertContents(
         0,
         new Delta()
@@ -1250,10 +1254,10 @@ describe('Editor', () => {
       const editor = createEditor(
         `
           <ol>
-            <li data-list="ordered">One</li>
-            <li data-list="ordered">Two</li>
-            <li data-list="bullet">Foo</li>
-            <li data-list="bullet">Bar</li>
+            <li class="ql-list-item ql-list-item-ordered">One</li>
+            <li class="ql-list-item ql-list-item-ordered">Two</li>
+            <li class="ql-list-item ql-list-item-bullet">Foo</li>
+            <li class="ql-list-item ql-list-item-bullet">Bar</li>
           </ol>
         `,
       );
@@ -1273,12 +1277,12 @@ describe('Editor', () => {
       const editor = createEditor(
         `
           <ol>
-            <li data-list="ordered">One</li>
-            <li data-list="ordered">Two</li>
-            <li data-list="bullet" class="ql-indent-1">Alpha</li>
-            <li data-list="ordered" class="ql-indent-2">I</li>
-            <li data-list="ordered" class="ql-indent-2">II</li>
-            <li data-list="ordered">Three</li>
+            <li class="ql-list-item ql-list-item-ordered">One</li>
+            <li class="ql-list-item ql-list-item-ordered">Two</li>
+            <li class="ql-list-item ql-list-item-bullet ql-indent-1">Alpha</li>
+            <li class="ql-list-item ql-list-item-ordered ql-indent-2">I</li>
+            <li class="ql-list-item ql-list-item-ordered ql-indent-2">II</li>
+            <li class="ql-list-item ql-list-item-ordered">Three</li>
           </ol>
         `,
       );
@@ -1304,29 +1308,29 @@ describe('Editor', () => {
       const editor = createEditor(
         `
           <ol>
-            <li data-list="checked">One</li>
-            <li data-list="checked">Two</li>
-            <li data-list="unchecked" class="ql-indent-1">Alpha</li>
-            <li data-list="checked" class="ql-indent-2">I</li>
-            <li data-list="checked" class="ql-indent-2">II</li>
-            <li data-list="checked">Three</li>
+            <li class="ql-list-item ql-list-item-checked">One</li>
+            <li class="ql-list-item ql-list-item-checked">Two</li>
+            <li class="ql-list-item ql-list-item-unchecked ql-indent-1">Alpha</li>
+            <li class="ql-list-item ql-list-item-checked ql-indent-2">I</li>
+            <li class="ql-list-item ql-list-item-checked ql-indent-2">II</li>
+            <li class="ql-list-item ql-list-item-checked">Three</li>
           </ol>
         `,
       );
       expect(editor.getHTML(2, 20)).toEqualHTML(`
         <ul>
-          <li data-list="checked">e</li>
-          <li data-list="checked">Two
+          <li class="ql-list-item ql-list-item-checked">e</li>
+          <li class="ql-list-item ql-list-item-checked">Two
             <ul>
-              <li data-list="unchecked">Alpha
+              <li class="ql-list-item ql-list-item-unchecked">Alpha
                 <ul>
-                  <li data-list="checked">I</li>
-                  <li data-list="checked">II</li>
+                  <li class="ql-list-item ql-list-item-checked">I</li>
+                  <li class="ql-list-item ql-list-item-checked">II</li>
                 </ul>
               </li>
             </ul>
           </li>
-          <li data-list="checked">Thr</li>
+          <li class="ql-list-item ql-list-item-checked">Thr</li>
         </ul>
       `);
     });
@@ -1335,11 +1339,11 @@ describe('Editor', () => {
       const editor = createEditor(
         `
         <ol>
-          <li data-list="ordered">1111</li>
-          <li data-list="ordered" class="ql-indent-1">AAAA</li>
-          <li data-list="ordered" class="ql-indent-2">IIII</li>
-          <li data-list="ordered" class="ql-indent-1">BBBB</li>
-          <li data-list="ordered">2222</li>
+          <li class="ql-list-item ql-list-item-ordered">1111</li>
+          <li class="ql-list-item ql-list-item-ordered ql-indent-1">AAAA</li>
+          <li class="ql-list-item ql-list-item-ordered ql-indent-2">IIII</li>
+          <li class="ql-list-item ql-list-item-ordered ql-indent-1">BBBB</li>
+          <li class="ql-list-item ql-list-item-ordered">2222</li>
         </ol>
         `,
       );

--- a/packages/quill/test/unit/core/selection.spec.ts
+++ b/packages/quill/test/unit/core/selection.spec.ts
@@ -123,7 +123,7 @@ describe('Selection', () => {
       const selection = createSelection(
         `<p><strong><em>01</em></strong></p>
         <ol>
-          <li data-list="bullet"><em><u>34</u></em></li>
+          <li class="ql-list-item ql-list-item-bullet"><em><u>34</u></em></li>
         </ol>`,
       );
       selection.setNativeRange(
@@ -168,7 +168,7 @@ describe('Selection', () => {
           <img src="/assets/favicon.png">
         </p>
         <ol>
-          <li data-list="bullet">
+          <li class="ql-list-item ql-list-item-bullet">
             <img src="/assets/favicon.png">
             <img src="/assets/favicon.png">
           </li>
@@ -204,8 +204,8 @@ describe('Selection', () => {
         <p>01</p>
         <p><br></p>
         <ol>
-          <li data-list="bullet">45</li>
-          <li data-list="bullet">78</li>
+          <li class="ql-list-item ql-list-item-bullet">45</li>
+          <li class="ql-list-item ql-list-item-bullet">78</li>
         </ol>`,
       );
       selection.setNativeRange(selection.root, 1, selection.root.lastChild, 1);
@@ -243,7 +243,7 @@ describe('Selection', () => {
         `
         <p><br></p>
         <ol>
-          <li data-list="bullet"><br></li>
+          <li class="ql-list-item ql-list-item-bullet"><br></li>
         </ol>`,
       );
       const expected = new Range(0, 1);
@@ -258,7 +258,7 @@ describe('Selection', () => {
         `
         <p><strong><em>01</em></strong></p>
         <ol>
-          <li data-list="bullet"><em><u>34</u></em></li>
+          <li class="ql-list-item ql-list-item-bullet"><em><u>34</u></em></li>
         </ol>`,
       );
       const expected = new Range(1, 3);
@@ -296,7 +296,7 @@ describe('Selection', () => {
           <img src="/assets/favicon.png">
         </p>
         <ol>
-          <li data-list="bullet">
+          <li class="ql-list-item ql-list-item-bullet">
             <img src="/assets/favicon.png">
             <img src="/assets/favicon.png">
           </li>

--- a/packages/quill/test/unit/formats/indent.spec.ts
+++ b/packages/quill/test/unit/formats/indent.spec.ts
@@ -14,7 +14,9 @@ const createScroll = (html: string) =>
 describe('Indent', () => {
   test('+1', () => {
     const editor = new Editor(
-      createScroll('<ol><li data-list="bullet">0123</li></ol>'),
+      createScroll(
+        '<ol><li class="ql-list-item ql-list-item-bullet">0123</li></ol>',
+      ),
     );
     editor.formatText(4, 1, { indent: '+1' });
     expect(editor.getDelta()).toEqual(
@@ -22,7 +24,7 @@ describe('Indent', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li class="ql-indent-1" data-list="bullet">0123</li>
+        <li class="ql-list-item ql-list-item-bullet ql-indent-1">0123</li>
       </ol>
     `);
   });
@@ -30,7 +32,7 @@ describe('Indent', () => {
   test('-1', () => {
     const editor = new Editor(
       createScroll(
-        '<ol><li data-list="bullet" class="ql-indent-1">0123</li></ol>',
+        '<ol><li class="ql-list-item ql-list-item-bullet ql-indent-1">0123</li></ol>',
       ),
     );
     editor.formatText(4, 1, { indent: '-1' });
@@ -39,7 +41,7 @@ describe('Indent', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="bullet">0123</li>
+        <li class="ql-list-item ql-list-item-bullet">0123</li>
       </ol>
     `);
   });

--- a/packages/quill/test/unit/formats/list.spec.ts
+++ b/packages/quill/test/unit/formats/list.spec.ts
@@ -34,7 +34,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <p>0123</p>
       <ol>
-        <li data-list="ordered">5678</li>
+        <li class="ql-list-item ql-list-item-ordered">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -63,8 +63,8 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="checked">0123</li>
-        <li data-list="unchecked">5678</li>
+        <li class="ql-list-item ql-list-item-checked">0123</li>
+        <li class="ql-list-item ql-list-item-unchecked">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -75,7 +75,7 @@ describe('List', () => {
       createScroll(
         `
       <p>0123</p>
-      <ol><li data-list="ordered">5678</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">5678</li></ol>
       <p>0123</p>
     `,
       ),
@@ -94,7 +94,7 @@ describe('List', () => {
       createScroll(
         `
       <p>0123</p>
-      <ol><li data-list="ordered">5678</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">5678</li></ol>
       <p>0123</p>
     `,
       ),
@@ -109,7 +109,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <p>0123</p>
       <ol>
-        <li data-list="bullet">5678</li>
+        <li class="ql-list-item ql-list-item-bullet">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -120,7 +120,7 @@ describe('List', () => {
       createScroll(
         `
       <ol>
-        <li data-list="checked">0123</li>
+        <li class="ql-list-item ql-list-item-checked">0123</li>
       </ol>
     `,
       ),
@@ -131,7 +131,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="bullet">0123</li>
+        <li class="ql-list-item ql-list-item-bullet">0123</li>
       </ol>
     `);
   });
@@ -139,7 +139,7 @@ describe('List', () => {
   test('replace with attributes', () => {
     const editor = new Editor(
       createScroll(
-        '<ol><li data-list="ordered" class="ql-align-center">0123</li></ol>',
+        '<ol><li class="ql-list-item ql-list-item-ordered ql-align-center">0123</li></ol>',
       ),
     );
     editor.formatText(4, 1, { list: 'bullet' });
@@ -150,7 +150,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li class="ql-align-center" data-list="bullet">0123</li>
+        <li class="ql-list-item ql-align-center ql-list-item-bullet">0123</li>
       </ol>
     `);
   });
@@ -159,9 +159,9 @@ describe('List', () => {
     const editor = new Editor(
       createScroll(
         `
-      <ol><li data-list="ordered">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">0123</li></ol>
       <p>5678</p>
-      <ol><li data-list="ordered">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">0123</li></ol>
     `,
       ),
     );
@@ -177,9 +177,9 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0123</li>
-        <li data-list="ordered">5678</li>
-        <li data-list="ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">5678</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
       </ol>
     `);
   });
@@ -188,9 +188,9 @@ describe('List', () => {
     const editor = new Editor(
       createScroll(
         `
-      <ol><li data-list="ordered">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">0123</li></ol>
       <p>5678</p>
-      <ol><li data-list="ordered">0123</li></ol>`,
+      <ol><li class="ql-list-item ql-list-item-ordered">0123</li></ol>`,
       ),
     );
     editor.deleteText(5, 5);
@@ -203,8 +203,8 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0123</li>
-        <li data-list="ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
       </ol>
     `);
   });
@@ -213,9 +213,9 @@ describe('List', () => {
     const editor = new Editor(
       createScroll(
         `
-      <ol><li data-list="checked">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-checked">0123</li></ol>
       <p>5678</p>
-      <ol><li data-list="checked">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-checked">0123</li></ol>
     `,
       ),
     );
@@ -231,27 +231,29 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="checked">0123</li>
-        <li data-list="checked">5678</li>
-        <li data-list="checked">0123</li>
+        <li class="ql-list-item ql-list-item-checked">0123</li>
+        <li class="ql-list-item ql-list-item-checked">5678</li>
+        <li class="ql-list-item ql-list-item-checked">0123</li>
       </ol>
     `);
   });
 
   test('empty line interop', () => {
     const editor = new Editor(
-      createScroll('<ol><li data-list="ordered"><br></li></ol>'),
+      createScroll(
+        '<ol><li class="ql-list-item ql-list-item-ordered"><br></li></ol>',
+      ),
     );
     editor.insertText(0, 'Test');
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Test</li>
+        <li class="ql-list-item ql-list-item-ordered">Test</li>
       </ol>
     `);
     editor.deleteText(0, 4);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered"><br /></li>
+        <li class="ql-list-item ql-list-item-ordered"><br /></li>
       </ol>
     `);
   });
@@ -261,17 +263,17 @@ describe('List', () => {
       createScroll(
         `
       <ol>
-        <li data-list="ordered">0123</li>
-        <li data-list="ordered">5678</li>
-        <li data-list="ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">5678</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
       </ol>`,
       ),
     );
     editor.deleteText(2, 5);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0178</li>
-        <li data-list="ordered">0123</li>
+        <li class="ql-list-item ql-list-item-ordered">0178</li>
+        <li class="ql-list-item ql-list-item-ordered">0123</li>
       </ol>
     `);
   });
@@ -280,7 +282,7 @@ describe('List', () => {
     const editor = new Editor(
       createScroll(
         `
-      <ol><li data-list="ordered">0123</li></ol>
+      <ol><li class="ql-list-item ql-list-item-ordered">0123</li></ol>
       <p>5678</p>`,
       ),
     );
@@ -290,12 +292,14 @@ describe('List', () => {
 
   test('delete partial', () => {
     const editor = new Editor(
-      createScroll('<p>0123</p><ol><li data-list="ordered">5678</li></ol>'),
+      createScroll(
+        '<p>0123</p><ol><li class="ql-list-item ql-list-item-ordered">5678</li></ol>',
+      ),
     );
     editor.deleteText(2, 5);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0178</li>
+        <li class="ql-list-item ql-list-item-ordered">0178</li>
       </ol>
     `);
   });
@@ -305,9 +309,9 @@ describe('List', () => {
       createScroll(
         `
       <ol>
-        <li data-list="bullet">One</li>
-        <li class="ql-indent-1" data-list="bullet">Alpha</li>
-        <li data-list="bullet">Two</li>
+        <li class="ql-list-item ql-list-item-bullet">One</li>
+        <li class="ql-list-item ql-list-item-bullet ql-indent-1">Alpha</li>
+        <li class="ql-list-item ql-list-item-bullet">Two</li>
       </ol>
     `,
       ),
@@ -315,28 +319,30 @@ describe('List', () => {
     editor.formatLine(1, 10, { list: 'bullet' });
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="bullet">One</li>
-        <li class="ql-indent-1" data-list="bullet">Alpha</li>
-        <li data-list="bullet">Two</li>
+        <li class="ql-list-item ql-list-item-bullet">One</li>
+        <li class="ql-list-item ql-indent-1 ql-list-item-bullet">Alpha</li>
+        <li class="ql-list-item ql-list-item-bullet">Two</li>
       </ol>
     `);
   });
 
-  test('copy atttributes', () => {
+  test('copy attributes', () => {
     const editor = new Editor(
       createScroll('<p class="ql-align-center">Test</p>'),
     );
     editor.formatLine(4, 1, { list: 'bullet' });
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li class="ql-align-center" data-list="bullet">Test</li>
+        <li class="ql-list-item ql-list-item-bullet ql-align-center">Test</li>
       </ol>
     `);
   });
 
   test('insert block embed', () => {
     const editor = new Editor(
-      createScroll('<ol><li data-list="ordered">Test</li></ol>'),
+      createScroll(
+        '<ol><li class="ql-list-item ql-list-item-ordered">Test</li></ol>',
+      ),
     );
     editor.insertEmbed(
       2,
@@ -345,18 +351,20 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Te</li>
+        <li class="ql-list-item ql-list-item-ordered">Te</li>
       </ol>
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>
-        <li data-list="ordered">st</li>
+        <li class="ql-list-item ql-list-item-ordered">st</li>
       </ol>
     `);
   });
 
   test('insert block embed at beginning', () => {
     const editor = new Editor(
-      createScroll('<ol><li data-list="ordered">Test</li></ol>'),
+      createScroll(
+        '<ol><li class="ql-list-item ql-list-item-ordered">Test</li></ol>',
+      ),
     );
     editor.insertEmbed(
       0,
@@ -366,14 +374,16 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>
-        <li data-list="ordered">Test</li>
+        <li class="ql-list-item ql-list-item-ordered">Test</li>
       </ol>
     `);
   });
 
   test('insert block embed at end', () => {
     const editor = new Editor(
-      createScroll('<ol><li data-list="ordered">Test</li></ol>'),
+      createScroll(
+        '<ol><li class="ql-list-item ql-list-item-ordered">Test</li></ol>',
+      ),
     );
     editor.insertEmbed(
       4,
@@ -382,11 +392,11 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Test</li>
+        <li class="ql-list-item ql-list-item-ordered">Test</li>
       </ol>
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>
-        <li data-list="ordered"><br /></li>
+        <li class="ql-list-item ql-list-item-ordered"><br /></li>
       </ol>
     `);
   });

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -399,8 +399,8 @@ describe('Clipboard', () => {
     test('html nested checklist', () => {
       const delta = createClipboard().convert({
         html:
-          '<ul><li data-list="checked">One<ul><li data-list="checked">Alpha</li><li data-list="checked">Beta' +
-          '<ul><li data-list="checked">I</li></ul></li></ul></li></ul>',
+          '<ul><li class="ql-list-item ql-list-item-checked">One<ul><li class="ql-list-item ql-list-item-checked">Alpha</li><li class="ql-list-item ql-list-item-checked">Beta' +
+          '<ul><li class="ql-list-item ql-list-item-checked">I</li></ul></li></ul></li></ul>',
       });
       expect(delta).toEqual(
         new Delta()

--- a/packages/quill/test/unit/modules/normalizeExternalHTML/normalizers/msWord.spec.ts
+++ b/packages/quill/test/unit/modules/normalizeExternalHTML/normalizers/msWord.spec.ts
@@ -25,21 +25,19 @@ describe('Microsoft Word', () => {
       HTMLCollection [
         <ul>
           <li
-            data-list="ordered"
+            class="ql-list-item ql-list-item-ordered"
           >
             item 1
           </li>
           <li
-            class="ql-indent-2"
-            data-list="bullet"
+            class="ql-list-item ql-list-item-bullet ql-indent-2"
           >
             item 2
           </li>
         </ul>,
         <ul>
           <li
-            class="ql-indent-3"
-            data-list="ordered"
+            class="ql-list-item ql-list-item-ordered ql-indent-3"
           >
             item 3 in another list
           </li>
@@ -49,7 +47,7 @@ describe('Microsoft Word', () => {
         </p>,
         <ul>
           <li
-            data-list="ordered"
+            class="ql-list-item ql-list-item-ordered"
           >
             the last item
           </li>


### PR DESCRIPTION
Sanitizers remove the [data attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*) from HTML to prevent XSS vulnerabilities.
I have noticed [Angular sanitizer](https://angular.dev/best-practices/security) is removing data attributes, as others can do as well (https://github.com/jitbit/HtmlSanitizer). 

The problem is that by losing data attributes, we are also losing the corresponding style.

The only data attributes used in Quill are for list items `<li>` : 
- `[data-list]=""`
- `[data-list]="checked"`
- `[data-list]="unchecked"`
- `[data-list]="bullet"`
- `[data-list]="ordered"`

Since `class` attribute is not sanitized, I propose to replace the`data-list` attribute with equivalent CSS classes : 
- `.ql-list-item`
- `.ql-list-item-checked`
- `.ql-list-item-unchecked`
- `.ql-list-item-bullet`
- `.ql-list-item-ordered`

It give the advantage to keep the list items information after sanitizing HTML content (that is a common requirement for rich text editor that produce HTML to show publicly). It also standardizes Quill format management while the list format was the only one depending on data attributes instead of CSS classes.