### PR TITLE
Preserves formatting on newline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7846,9 +7846,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001597",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
-      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
+      "version": "1.0.30001689",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
+      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
       "funding": [
         {
           "type": "opencollective",

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -332,6 +332,7 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleEnter(range: Range, context: Context) {
+    //console.log('🪶 Quill - handleEnter: ', range, context);
     const lineFormats = Object.keys(context.format).reduce(
       (formats: Record<string, unknown>, format) => {
         if (
@@ -344,23 +345,33 @@ class Keyboard extends Module<KeyboardOptions> {
       },
       {},
     );
+
+    // [Customized for TextJam]
+    // If there is a space character at the end of the line when we hit enter, delete it
+    //const isSpaceAtEnd = range.index + range.length - 1 > 0 && this.quill.getText(range.index + range.length - 1, 1) === ' ';
+    //const deleteExtraLength = isSpaceAtEnd ? 1 : 0;
+    const deleteExtraLength = 0;
+    
+    // [Customized for TextJam]
+    // Go ahead and apply our deltas now, and adjust if we're deleting a space
     const delta = new Delta()
-      .retain(range.index)
-      .delete(range.length)
+      .retain(range.index - deleteExtraLength)
+      .delete(range.length + deleteExtraLength)
       .insert('\n', lineFormats);
     this.quill.updateContents(delta, Quill.sources.USER);
-    this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
+    this.quill.setSelection(range.index + 1 - deleteExtraLength, Quill.sources.SILENT);
     this.quill.focus();
 
+    // [Customized for TextJam]
     // Preserve the format of the text from the prior line
-    // Customized for TextJam
+    // Reverted from earlier version of Quill
+    /*
     Object.keys(context.format).forEach(name => {
       if (lineFormats[name] != null) return;
       if (Array.isArray(context.format[name])) return;
       if (name === 'code' || name === 'link') return;
       this.quill.format(name, context.format[name], Quill.sources.USER);
-    });
-
+    });*/
 
   }
 }

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -351,6 +351,17 @@ class Keyboard extends Module<KeyboardOptions> {
     this.quill.updateContents(delta, Quill.sources.USER);
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
     this.quill.focus();
+
+    // Preserve the format of the text from the prior line
+    // Customized for TextJam
+    Object.keys(context.format).forEach(name => {
+      if (lineFormats[name] != null) return;
+      if (Array.isArray(context.format[name])) return;
+      if (name === 'code' || name === 'link') return;
+      this.quill.format(name, context.format[name], Quill.sources.USER);
+    });
+
+
   }
 }
 


### PR DESCRIPTION
Reverts a change in Quill 2.0 that stopped preserving the current format when a newline is added, to make the behavior more in line with user's normal word processing experience (in things like Google Doc).