### PR TITLE
add soft line breaks

### DIFF
--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -108,9 +108,9 @@ class Block extends BlockBlot {
 
     // in order for an end-of-block soft break to be rendered properly by the browser, we need a trailing break
     if (
-      lastLeafInBlock != null
-      && lastLeafInBlock.statics.blotName === SoftBreak.blotName
-      && this.children.tail?.statics.blotName !== Break.blotName
+      lastLeafInBlock != null &&
+      lastLeafInBlock.statics.blotName === SoftBreak.blotName &&
+      this.children.tail?.statics.blotName !== Break.blotName
     ) {
       const breakBlot = this.scroll.create(Break.blotName);
       super.insertBefore(breakBlot, null);
@@ -214,10 +214,10 @@ export function getLastLeafInParent(blot: ParentBlot): Blot | null {
     if (current instanceof ParentBlot) {
       current = current.children.tail;
     } else {
-      return current
+      return current;
     }
   }
-  return null
+  return null;
 }
 
 function blockDelta(blot: BlockBlot, filter = true) {

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -3,7 +3,6 @@ import {
   BlockBlot,
   EmbedBlot,
   LeafBlot,
-  ParentBlot,
   Scope,
 } from 'parchment';
 import type { Blot, Parent } from 'parchment';
@@ -104,7 +103,7 @@ class Block extends BlockBlot {
 
   optimize(context: { [key: string]: any }) {
     super.optimize(context);
-    const lastLeafInBlock = getLastLeafInParent(this);
+    const lastLeafInBlock = this.descendants(LeafBlot).at(-1);
 
     // in order for an end-of-block soft break to be rendered properly by the browser, we need a trailing break
     if (
@@ -206,19 +205,6 @@ class BlockEmbed extends EmbedBlot {
 }
 BlockEmbed.scope = Scope.BLOCK_BLOT;
 // It is important for cursor behavior BlockEmbeds use tags that are block level elements
-
-export function getLastLeafInParent(blot: ParentBlot): Blot | null {
-  let current = blot.children.tail;
-  const MAX_ITERATIONS = 1000;
-  for (let i = 0; current != null && i < MAX_ITERATIONS; i++) {
-    if (current instanceof ParentBlot) {
-      current = current.children.tail;
-    } else {
-      return current;
-    }
-  }
-  return null;
-}
 
 function blockDelta(blot: BlockBlot, filter = true) {
   return blot

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -62,10 +62,28 @@ class Block extends BlockBlot {
       const softLines = text.split(softBreakRegex);
       let i = index;
       softLines.forEach((str) => {
-        if (str === SOFT_BREAK_CHARACTER) {
-          super.insertAt(i, SoftBreak.blotName, SOFT_BREAK_CHARACTER);
+        if (i < this.length() - 1 || this.children.tail == null) {
+          const insertIndex = Math.min(i, this.length() - 1);
+          if (str === SOFT_BREAK_CHARACTER) {
+            super.insertAt(
+              insertIndex,
+              SoftBreak.blotName,
+              SOFT_BREAK_CHARACTER,
+            );
+          } else {
+            super.insertAt(insertIndex, str);
+          }
         } else {
-          super.insertAt(Math.min(i, this.length() - 1), str);
+          const insertIndex = this.children.tail.length();
+          if (str === SOFT_BREAK_CHARACTER) {
+            this.children.tail.insertAt(
+              insertIndex,
+              SoftBreak.blotName,
+              SOFT_BREAK_CHARACTER,
+            );
+          } else {
+            this.children.tail.insertAt(insertIndex, str);
+          }
         }
         i += str.length;
       });

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -13,7 +13,7 @@ import TextBlot from './text.js';
 import SoftBreak, { SOFT_BREAK_CHARACTER } from './soft-break.js';
 
 const NEWLINE_LENGTH = 1;
-const softBreakRegex = new RegExp(`(${SOFT_BREAK_CHARACTER})`, "g");
+const softBreakRegex = new RegExp(`(${SOFT_BREAK_CHARACTER})`, 'g');
 
 class Block extends BlockBlot {
   cache: { delta?: Delta | null; length?: number } = {};
@@ -27,9 +27,9 @@ class Block extends BlockBlot {
 
   deleteAt(index: number, length: number) {
     super.deleteAt(index, length);
-    this.children.forEach(child => {
+    this.children.forEach((child) => {
       if (child instanceof Break) {
-        child.optimize()
+        child.optimize();
       }
     });
     this.cache = {};
@@ -49,9 +49,9 @@ class Block extends BlockBlot {
         value,
       );
     }
-    this.children.forEach(child => {
+    this.children.forEach((child) => {
       if (child instanceof Break) {
-        child.optimize()
+        child.optimize();
       }
     });
     this.cache = {};
@@ -69,13 +69,13 @@ class Block extends BlockBlot {
     if (text.length > 0) {
       const softLines = text.split(softBreakRegex);
       let i = index;
-      softLines.forEach(str => {
+      softLines.forEach((str) => {
         if (str === SOFT_BREAK_CHARACTER) {
           super.insertAt(i, SoftBreak.blotName, SOFT_BREAK_CHARACTER);
         } else {
           super.insertAt(Math.min(i, this.length() - 1), str);
         }
-        i += str.length
+        i += str.length;
       });
 
       this.cache = {};
@@ -93,9 +93,9 @@ class Block extends BlockBlot {
 
   insertBefore(blot: Blot, ref?: Blot | null) {
     super.insertBefore(blot, ref);
-    this.children.forEach(child => {
+    this.children.forEach((child) => {
       if (child instanceof Break) {
-        child.optimize()
+        child.optimize();
       }
     });
     this.cache = {};
@@ -116,8 +116,11 @@ class Block extends BlockBlot {
   optimize(context: { [key: string]: any }) {
     super.optimize(context);
 
-    // in order for an end-of-block soft break to be rendered properly by the browser, we need a trailing break  
-    if (this.children.length > 0 && this.children.tail?.statics.blotName === SoftBreak.blotName) {
+    // in order for an end-of-block soft break to be rendered properly by the browser, we need a trailing break
+    if (
+      this.children.length > 0 &&
+      this.children.tail?.statics.blotName === SoftBreak.blotName
+    ) {
       const breakBlot = this.scroll.create(Break.blotName);
       super.insertBefore(breakBlot, null);
     }

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -27,11 +27,7 @@ class Block extends BlockBlot {
 
   deleteAt(index: number, length: number) {
     super.deleteAt(index, length);
-    this.children.forEach((child) => {
-      if (child instanceof Break) {
-        child.optimize();
-      }
-    });
+    this.optimizeChildren();
     this.cache = {};
   }
 
@@ -49,11 +45,7 @@ class Block extends BlockBlot {
         value,
       );
     }
-    this.children.forEach((child) => {
-      if (child instanceof Break) {
-        child.optimize();
-      }
-    });
+    this.optimizeChildren();
     this.cache = {};
   }
 
@@ -93,11 +85,7 @@ class Block extends BlockBlot {
 
   insertBefore(blot: Blot, ref?: Blot | null) {
     super.insertBefore(blot, ref);
-    this.children.forEach((child) => {
-      if (child instanceof Break) {
-        child.optimize();
-      }
-    });
+    this.optimizeChildren();
     this.cache = {};
   }
 
@@ -149,6 +137,14 @@ class Block extends BlockBlot {
     const next = super.split(index, force);
     this.cache = {};
     return next;
+  }
+
+  private optimizeChildren() {
+    this.children.forEach((child) => {
+      if (child instanceof Break) {
+        child.optimize();
+      }
+    });
   }
 }
 Block.blotName = 'block';

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -10,8 +10,10 @@ import Delta from 'quill-delta';
 import Break from './break.js';
 import Inline from './inline.js';
 import TextBlot from './text.js';
+import SoftBreak, { SOFT_BREAK_CHARACTER } from './soft-break.js';
 
 const NEWLINE_LENGTH = 1;
+const softBreakRegex = new RegExp(`(${SOFT_BREAK_CHARACTER})`, "g");
 
 class Block extends BlockBlot {
   cache: { delta?: Delta | null; length?: number } = {};
@@ -25,6 +27,11 @@ class Block extends BlockBlot {
 
   deleteAt(index: number, length: number) {
     super.deleteAt(index, length);
+    this.children.forEach(child => {
+      if (child instanceof Break) {
+        child.optimize()
+      }
+    });
     this.cache = {};
   }
 
@@ -42,6 +49,11 @@ class Block extends BlockBlot {
         value,
       );
     }
+    this.children.forEach(child => {
+      if (child instanceof Break) {
+        child.optimize()
+      }
+    });
     this.cache = {};
   }
 
@@ -55,11 +67,17 @@ class Block extends BlockBlot {
     const lines = value.split('\n');
     const text = lines.shift() as string;
     if (text.length > 0) {
-      if (index < this.length() - 1 || this.children.tail == null) {
-        super.insertAt(Math.min(index, this.length() - 1), text);
-      } else {
-        this.children.tail.insertAt(this.children.tail.length(), text);
-      }
+      const softLines = text.split(softBreakRegex);
+      let i = index;
+      softLines.forEach(str => {
+        if (str === SOFT_BREAK_CHARACTER) {
+          super.insertAt(i, SoftBreak.blotName, SOFT_BREAK_CHARACTER);
+        } else {
+          super.insertAt(Math.min(i, this.length() - 1), str);
+        }
+        i += str.length
+      });
+
       this.cache = {};
     }
     // TODO: Fix this next time the file is edited.
@@ -74,11 +92,12 @@ class Block extends BlockBlot {
   }
 
   insertBefore(blot: Blot, ref?: Blot | null) {
-    const { head } = this.children;
     super.insertBefore(blot, ref);
-    if (head instanceof Break) {
-      head.remove();
-    }
+    this.children.forEach(child => {
+      if (child instanceof Break) {
+        child.optimize()
+      }
+    });
     this.cache = {};
   }
 
@@ -96,6 +115,12 @@ class Block extends BlockBlot {
 
   optimize(context: { [key: string]: any }) {
     super.optimize(context);
+
+    // in order for an end-of-block soft break to be rendered properly by the browser, we need a trailing break  
+    if (this.children.length > 0 && this.children.tail?.statics.blotName === SoftBreak.blotName) {
+      const breakBlot = this.scroll.create(Break.blotName);
+      super.insertBefore(breakBlot, null);
+    }
     this.cache = {};
   }
 

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,5 +1,6 @@
-import { EmbedBlot } from 'parchment';
+import { Blot, EmbedBlot, ParentBlot } from 'parchment';
 import SoftBreak from './soft-break.js';
+import { getLastLeafInParent } from './block.js';
 
 class Break extends EmbedBlot {
   static value() {
@@ -8,11 +9,11 @@ class Break extends EmbedBlot {
 
   optimize(): void {
     const thisIsLastBlotInParent = this.next == null;
-    const noPrevBlots = this.prev == null;
-    const prevBlotIsSoftBreak =
-      this.prev != null && this.prev.statics.blotName == SoftBreak.blotName;
-    const shouldRender =
-      thisIsLastBlotInParent && (noPrevBlots || prevBlotIsSoftBreak);
+    const thisIsFirstBlotInParent = this.prev == null;
+    const thisIsOnlyBlotInParent = thisIsLastBlotInParent && thisIsFirstBlotInParent
+    const prevLeaf = this.prev instanceof ParentBlot ? getLastLeafInParent(this.prev) : this.prev
+    const prevLeafIsSoftBreak = prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
+    const shouldRender = thisIsOnlyBlotInParent || prevLeafIsSoftBreak;
     if (!shouldRender) {
       this.remove();
     }
@@ -28,5 +29,6 @@ class Break extends EmbedBlot {
 }
 Break.blotName = 'break';
 Break.tagName = 'BR';
+
 
 export default Break;

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,4 +1,4 @@
-import { Blot, EmbedBlot, ParentBlot } from 'parchment';
+import { EmbedBlot, ParentBlot } from 'parchment';
 import SoftBreak from './soft-break.js';
 import { getLastLeafInParent } from './block.js';
 
@@ -10,9 +10,14 @@ class Break extends EmbedBlot {
   optimize(): void {
     const thisIsLastBlotInParent = this.next == null;
     const thisIsFirstBlotInParent = this.prev == null;
-    const thisIsOnlyBlotInParent = thisIsLastBlotInParent && thisIsFirstBlotInParent
-    const prevLeaf = this.prev instanceof ParentBlot ? getLastLeafInParent(this.prev) : this.prev
-    const prevLeafIsSoftBreak = prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
+    const thisIsOnlyBlotInParent =
+      thisIsLastBlotInParent && thisIsFirstBlotInParent;
+    const prevLeaf =
+      this.prev instanceof ParentBlot
+        ? getLastLeafInParent(this.prev)
+        : this.prev;
+    const prevLeafIsSoftBreak =
+      prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
     const shouldRender = thisIsOnlyBlotInParent || prevLeafIsSoftBreak;
     if (!shouldRender) {
       this.remove();
@@ -29,6 +34,5 @@ class Break extends EmbedBlot {
 }
 Break.blotName = 'break';
 Break.tagName = 'BR';
-
 
 export default Break;

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,6 +1,5 @@
-import { EmbedBlot, ParentBlot } from 'parchment';
+import { EmbedBlot, LeafBlot, ParentBlot } from 'parchment';
 import SoftBreak from './soft-break.js';
-import { getLastLeafInParent } from './block.js';
 
 class Break extends EmbedBlot {
   static value() {
@@ -14,7 +13,7 @@ class Break extends EmbedBlot {
       thisIsLastBlotInParent && thisIsFirstBlotInParent;
     const prevLeaf =
       this.prev instanceof ParentBlot
-        ? getLastLeafInParent(this.prev)
+        ? this.prev.descendants(LeafBlot).at(-1)
         : this.prev;
     const prevLeafIsSoftBreak =
       prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,5 +1,5 @@
 import { EmbedBlot } from 'parchment';
-import SoftBreak from './soft-break';
+import SoftBreak from './soft-break.js';
 
 class Break extends EmbedBlot {
   static value() {
@@ -9,10 +9,12 @@ class Break extends EmbedBlot {
   optimize(): void {
     const thisIsLastBlotInParent = this.next == null;
     const noPrevBlots = this.prev == null;
-    const prevBlotIsSoftBreak = this.prev != null && this.prev.statics.blotName == SoftBreak.blotName;
-    const shouldRender = thisIsLastBlotInParent && (noPrevBlots || prevBlotIsSoftBreak)
+    const prevBlotIsSoftBreak =
+      this.prev != null && this.prev.statics.blotName == SoftBreak.blotName;
+    const shouldRender =
+      thisIsLastBlotInParent && (noPrevBlots || prevBlotIsSoftBreak);
     if (!shouldRender) {
-        this.remove()
+      this.remove();
     }
   }
 

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,13 +1,18 @@
 import { EmbedBlot } from 'parchment';
+import SoftBreak from './soft-break';
 
 class Break extends EmbedBlot {
   static value() {
     return undefined;
   }
 
-  optimize() {
-    if (this.prev || this.next) {
-      this.remove();
+  optimize(): void {
+    const thisIsLastBlotInParent = this.next == null;
+    const noPrevBlots = this.prev == null;
+    const prevBlotIsSoftBreak = this.prev != null && this.prev.statics.blotName == SoftBreak.blotName;
+    const shouldRender = thisIsLastBlotInParent && (noPrevBlots || prevBlotIsSoftBreak)
+    if (!shouldRender) {
+        this.remove()
     }
   }
 

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -17,7 +17,8 @@ class Break extends EmbedBlot {
         : this.prev;
     const prevLeafIsSoftBreak =
       prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
-    const shouldRender =  thisIsOnlyBlotInParent || (thisIsLastBlotInParent && prevLeafIsSoftBreak);
+    const shouldRender =
+      thisIsOnlyBlotInParent || (thisIsLastBlotInParent && prevLeafIsSoftBreak);
     if (!shouldRender) {
       this.remove();
     }

--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -17,7 +17,7 @@ class Break extends EmbedBlot {
         : this.prev;
     const prevLeafIsSoftBreak =
       prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
-    const shouldRender = thisIsOnlyBlotInParent || prevLeafIsSoftBreak;
+    const shouldRender =  thisIsOnlyBlotInParent || (thisIsLastBlotInParent && prevLeafIsSoftBreak);
     if (!shouldRender) {
       this.remove();
     }

--- a/packages/quill/src/blots/soft-break.ts
+++ b/packages/quill/src/blots/soft-break.ts
@@ -1,21 +1,21 @@
-import { EmbedBlot } from "parchment";
+import { EmbedBlot } from 'parchment';
 
-export const SOFT_BREAK_CHARACTER = "\u2028";
+export const SOFT_BREAK_CHARACTER = '\u2028';
 
 export default class SoftBreak extends EmbedBlot {
-  static tagName = "BR";
+  static tagName = 'BR';
   static blotName: string = 'soft-break';
   static className: string = 'soft-break';
-  
+
   length(): number {
-    return 1
+    return 1;
   }
 
   value(): string {
-    return SOFT_BREAK_CHARACTER
+    return SOFT_BREAK_CHARACTER;
   }
 
   optimize(): void {
-    return
+    return;
   }
 }

--- a/packages/quill/src/blots/soft-break.ts
+++ b/packages/quill/src/blots/soft-break.ts
@@ -1,0 +1,21 @@
+import { EmbedBlot } from "parchment";
+
+export const SOFT_BREAK_CHARACTER = "\u2028";
+
+export default class SoftBreak extends EmbedBlot {
+  static tagName = "BR";
+  static blotName: string = 'soft-break';
+  static className: string = 'soft-break';
+  
+  length(): number {
+    return 1
+  }
+
+  value(): string {
+    return SOFT_BREAK_CHARACTER
+  }
+
+  optimize(): void {
+    return
+  }
+}

--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -39,7 +39,7 @@ Quill.register({
   'blots/block': Block,
   'blots/block/embed': BlockEmbed,
   'blots/break': Break,
-  "blots/soft-break": SoftBreak,
+  'blots/soft-break': SoftBreak,
   'blots/container': Container,
   'blots/cursor': Cursor,
   'blots/embed': Embed,

--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -15,6 +15,7 @@ import Embed from './blots/embed.js';
 import Inline from './blots/inline.js';
 import Scroll from './blots/scroll.js';
 import TextBlot from './blots/text.js';
+import SoftBreak from './blots/soft-break.js';
 
 import Clipboard from './modules/clipboard.js';
 import History from './modules/history.js';
@@ -38,6 +39,7 @@ Quill.register({
   'blots/block': Block,
   'blots/block/embed': BlockEmbed,
   'blots/break': Break,
+  "blots/soft-break": SoftBreak,
   'blots/container': Container,
   'blots/cursor': Cursor,
   'blots/embed': Embed,

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -219,6 +219,7 @@ class Editor {
     const normalizedDelta = normalizeDelta(contents);
     const change = new Delta().retain(index).concat(normalizedDelta);
     this.scroll.insertContents(index, normalizedDelta);
+    this.scroll.optimize();
     return this.update(change);
   }
 

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -23,6 +23,7 @@ import { FontStyle } from '../formats/font.js';
 import { SizeStyle } from '../formats/size.js';
 import { deleteRange } from './keyboard.js';
 import normalizeExternalHTML from './normalizeExternalHTML/index.js';
+import { SOFT_BREAK_CHARACTER } from '../blots/soft-break.js';
 
 const debug = logger('quill:clipboard');
 
@@ -33,6 +34,7 @@ const CLIPBOARD_CONFIG: [Selector, Matcher][] = [
   [Node.TEXT_NODE, matchText],
   [Node.TEXT_NODE, matchNewline],
   ['br', matchBreak],
+  ['br.soft-break', matchSoftBreak],
   [Node.ELEMENT_NODE, matchNewline],
   [Node.ELEMENT_NODE, matchBlot],
   [Node.ELEMENT_NODE, matchAttributor],
@@ -494,6 +496,10 @@ function matchBreak(node: Node, delta: Delta) {
     delta.insert('\n');
   }
   return delta;
+}
+
+function matchSoftBreak(node: Node, delta: Delta) {
+  return new Delta().insert(SOFT_BREAK_CHARACTER)
 }
 
 function matchCodeBlock(node: Node, delta: Delta, scroll: ScrollBlot) {

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -491,7 +491,7 @@ function matchBlot(node: Node, delta: Delta, scroll: ScrollBlot) {
 }
 
 function matchBreak(node: Node, delta: Delta, scroll: ScrollBlot) {
-  let parentLineElement = getParentLine(node, scroll);
+  const parentLineElement = getParentLine(node, scroll);
   if (parentLineElement == null) {
     // <br> tags pasted without a parent will be treated as soft breaks
     return new Delta().insert(SOFT_BREAK_CHARACTER);

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -34,7 +34,6 @@ const CLIPBOARD_CONFIG: [Selector, Matcher][] = [
   [Node.TEXT_NODE, matchText],
   [Node.TEXT_NODE, matchNewline],
   ['br', matchBreak],
-  ['br.soft-break', matchSoftBreak],
   [Node.ELEMENT_NODE, matchNewline],
   [Node.ELEMENT_NODE, matchBlot],
   [Node.ELEMENT_NODE, matchAttributor],
@@ -491,15 +490,46 @@ function matchBlot(node: Node, delta: Delta, scroll: ScrollBlot) {
   return delta;
 }
 
-function matchBreak(node: Node, delta: Delta) {
-  if (!deltaEndsWith(delta, '\n')) {
-    delta.insert('\n');
+function matchBreak(node: Node, delta: Delta, scroll: ScrollBlot) {
+  let parentLineElement = getParentLine(node, scroll);
+  if (parentLineElement == null) {
+    // <br> tags pasted without a parent will be treated as soft breaks
+    return new Delta().insert(SOFT_BREAK_CHARACTER);
   }
-  return delta;
+  if (isPre(parentLineElement)) {
+    // code blocks don't allow soft breaks
+    return new Delta().insert('\n');
+  }
+  if (isInLastPositionOfParentLine(node, parentLineElement)) {
+    // ignore trailing breaks
+    return delta;
+  }
+  return new Delta().insert(SOFT_BREAK_CHARACTER);
 }
 
-function matchSoftBreak() {
-  return new Delta().insert(SOFT_BREAK_CHARACTER);
+function getParentLine(node: Node, scroll: ScrollBlot): HTMLElement | null {
+  let current: Node = node;
+  while (current.parentElement != null) {
+    if (isLine(current.parentElement, scroll)) {
+      return current.parentElement;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function isInLastPositionOfParentLine(
+  node: Node,
+  parentLineElement: HTMLElement,
+): boolean {
+  let current: Node = node;
+  while (current.nextSibling == null && current.parentElement != null) {
+    if (current.parentElement === parentLineElement) {
+      return true;
+    }
+    current = current.parentElement;
+  }
+  return false;
 }
 
 function matchCodeBlock(node: Node, delta: Delta, scroll: ScrollBlot) {

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -498,8 +498,8 @@ function matchBreak(node: Node, delta: Delta) {
   return delta;
 }
 
-function matchSoftBreak(node: Node, delta: Delta) {
-  return new Delta().insert(SOFT_BREAK_CHARACTER)
+function matchSoftBreak() {
+  return new Delta().insert(SOFT_BREAK_CHARACTER);
 }
 
 function matchCodeBlock(node: Node, delta: Delta, scroll: ScrollBlot) {

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -7,6 +7,7 @@ import logger from '../core/logger.js';
 import Module from '../core/module.js';
 import type { BlockEmbed } from '../blots/block.js';
 import type { Range } from '../core/selection.js';
+import SoftBreak, { SOFT_BREAK_CHARACTER } from '../blots/soft-break.js';
 
 const debug = logger('quill:keyboard');
 
@@ -84,6 +85,13 @@ class Keyboard extends Module<KeyboardOptions> {
         this.addBinding(this.options.bindings[name]);
       }
     });
+    this.addBinding(
+      {
+        key: "Enter",
+        shiftKey: true,
+      },
+      this.handleShiftEnter
+    )
     this.addBinding({ key: 'Enter', shiftKey: null }, this.handleEnter);
     this.addBinding(
       { key: 'Enter', metaKey: null, ctrlKey: null, altKey: null },
@@ -351,6 +359,11 @@ class Keyboard extends Module<KeyboardOptions> {
     this.quill.updateContents(delta, Quill.sources.USER);
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
     this.quill.focus();
+  }
+
+  handleShiftEnter(range: Range) {
+    this.quill.insertEmbed(range.index, SoftBreak.blotName, SOFT_BREAK_CHARACTER)
+    this.quill.setSelection(range.index + 1);
   }
 }
 

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -7,7 +7,7 @@ import logger from '../core/logger.js';
 import Module from '../core/module.js';
 import type { BlockEmbed } from '../blots/block.js';
 import type { Range } from '../core/selection.js';
-import SoftBreak, { SOFT_BREAK_CHARACTER } from '../blots/soft-break.js';
+import { SOFT_BREAK_CHARACTER } from '../blots/soft-break.js';
 
 const debug = logger('quill:keyboard');
 

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -362,11 +362,7 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleShiftEnter(range: Range) {
-    this.quill.insertEmbed(
-      range.index,
-      SoftBreak.blotName,
-      SOFT_BREAK_CHARACTER,
-    );
+    this.quill.insertText(range.index, SOFT_BREAK_CHARACTER);
     this.quill.setSelection(range.index + 1);
   }
 }

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -362,7 +362,11 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleShiftEnter(range: Range) {
-    this.quill.insertText(range.index, SOFT_BREAK_CHARACTER, Quill.sources.USER);
+    this.quill.insertText(
+      range.index,
+      SOFT_BREAK_CHARACTER,
+      Quill.sources.USER,
+    );
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
   }
 }

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -87,11 +87,11 @@ class Keyboard extends Module<KeyboardOptions> {
     });
     this.addBinding(
       {
-        key: "Enter",
+        key: 'Enter',
         shiftKey: true,
       },
-      this.handleShiftEnter
-    )
+      this.handleShiftEnter,
+    );
     this.addBinding({ key: 'Enter', shiftKey: null }, this.handleEnter);
     this.addBinding(
       { key: 'Enter', metaKey: null, ctrlKey: null, altKey: null },
@@ -362,7 +362,11 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleShiftEnter(range: Range) {
-    this.quill.insertEmbed(range.index, SoftBreak.blotName, SOFT_BREAK_CHARACTER)
+    this.quill.insertEmbed(
+      range.index,
+      SoftBreak.blotName,
+      SOFT_BREAK_CHARACTER,
+    );
     this.quill.setSelection(range.index + 1);
   }
 }

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -362,8 +362,8 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleShiftEnter(range: Range) {
-    this.quill.insertText(range.index, SOFT_BREAK_CHARACTER);
-    this.quill.setSelection(range.index + 1);
+    this.quill.insertText(range.index, SOFT_BREAK_CHARACTER, Quill.sources.USER);
+    this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
   }
 }
 

--- a/packages/quill/test/e2e/__dev_server__/index.html
+++ b/packages/quill/test/e2e/__dev_server__/index.html
@@ -1,74 +1,75 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, user-scalable=no"
+    />
+    <title>Quill E2E Tests</title>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+    <link href="/quill.core.css" rel="stylesheet" />
+    <link href="/quill.snow.css" rel="stylesheet" />
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-  <title>Quill E2E Tests</title>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-  <link href="/quill.core.css" rel="stylesheet">
-  <link href="/quill.snow.css" rel="stylesheet">
-</head>
-
-<body>
-  <div id="root">
-    <div id="standalone-container">
-      <div id="toolbar-container">
-        <span class="ql-formats">
-          <select class="ql-font"></select>
-          <select class="ql-size"></select>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-bold"></button>
-          <button class="ql-italic"></button>
-          <button class="ql-underline"></button>
-          <button class="ql-strike"></button>
-        </span>
-        <span class="ql-formats">
-          <select class="ql-color"></select>
-          <select class="ql-background"></select>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-script" value="sub"></button>
-          <button class="ql-script" value="super"></button>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-header" value="1"></button>
-          <button class="ql-header" value="2"></button>
-          <button class="ql-blockquote"></button>
-          <button class="ql-code-block"></button>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-list" value="ordered"></button>
-          <button class="ql-list" value="bullet"></button>
-          <button class="ql-indent" value="-1"></button>
-          <button class="ql-indent" value="+1"></button>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-direction" value="rtl"></button>
-          <select class="ql-align"></select>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-link"></button>
-          <button class="ql-image"></button>
-          <button class="ql-video"></button>
-          <button class="ql-formula"></button>
-        </span>
-        <span class="ql-formats">
-          <button class="ql-clean"></button>
-        </span>
+  <body>
+    <div id="root">
+      <div id="standalone-container">
+        <div id="toolbar-container">
+          <span class="ql-formats">
+            <select class="ql-font"></select>
+            <select class="ql-size"></select>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-bold"></button>
+            <button class="ql-italic"></button>
+            <button class="ql-underline"></button>
+            <button class="ql-strike"></button>
+          </span>
+          <span class="ql-formats">
+            <select class="ql-color"></select>
+            <select class="ql-background"></select>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-script" value="sub"></button>
+            <button class="ql-script" value="super"></button>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-header" value="1"></button>
+            <button class="ql-header" value="2"></button>
+            <button class="ql-blockquote"></button>
+            <button class="ql-code-block"></button>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-list" value="ordered"></button>
+            <button class="ql-list" value="bullet"></button>
+            <button class="ql-indent" value="-1"></button>
+            <button class="ql-indent" value="+1"></button>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-direction" value="rtl"></button>
+            <select class="ql-align"></select>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-link"></button>
+            <button class="ql-image"></button>
+            <button class="ql-video"></button>
+            <button class="ql-formula"></button>
+          </span>
+          <span class="ql-formats">
+            <button class="ql-clean"></button>
+          </span>
+        </div>
+        <div id="editor" style="height: 350px"></div>
+        <script>
+          window.quill = new Quill(document.getElementById('editor'), {
+            modules: { syntax: true, toolbar: '#toolbar-container' },
+            placeholder: 'Compose an epic...',
+            theme: 'snow',
+          });
+        </script>
       </div>
-      <div id="editor" style="height: 350px;">
-      </div>
-      <script>
-        window.quill = new Quill(document.getElementById('editor'), {
-          modules: { syntax: true, toolbar: '#toolbar-container', },
-          placeholder: 'Compose an epic...', theme: 'snow',
-        })
-      </script>
     </div>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/packages/quill/test/unit/__helpers__/factory.ts
+++ b/packages/quill/test/unit/__helpers__/factory.ts
@@ -10,6 +10,7 @@ import ListItem, { ListContainer } from '../../../src/formats/list.js';
 import Inline from '../../../src/blots/inline.js';
 import Emitter from '../../../src/core/emitter.js';
 import { normalizeHTML } from './utils.js';
+import SoftBreak from '../../../src/blots/soft-break.js';
 
 export const createRegistry = (formats: unknown[] = []) => {
   const registry = new Registry();
@@ -19,6 +20,7 @@ export const createRegistry = (formats: unknown[] = []) => {
   });
   registry.register(Block);
   registry.register(Break);
+  registry.register(SoftBreak);
   registry.register(Cursor);
   registry.register(Inline);
   registry.register(Scroll);

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -292,16 +292,16 @@ describe('Editor', () => {
     });
 
     test('text before soft line break', () => {
-      const editor = createEditor(
-        '<p>0<br class="soft-break" />1</p>',
-      );
+      const editor = createEditor('<p>0<br class="soft-break" />1</p>');
       editor.deleteText(2, 1);
       expect(editor.getDelta()).toEqual(
         new Delta().insert(`0${SOFT_BREAK_CHARACTER}`).insert('\n'),
       );
       // importantly deleting the character after a soft break, such that the soft break becomes
       // the last leaf in the block, should add the trailing break
-      expect(editor.scroll.domNode).toEqualHTML('<p>0<br class="soft-break" /><br /></p>');
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<p>0<br class="soft-break" /><br /></p>',
+      );
     });
 
     test('text before soft line break within an inline parent', () => {
@@ -310,11 +310,15 @@ describe('Editor', () => {
       );
       editor.deleteText(2, 1);
       expect(editor.getDelta()).toEqual(
-        new Delta().insert(`0${SOFT_BREAK_CHARACTER}`, {bold: true}).insert('\n'),
+        new Delta()
+          .insert(`0${SOFT_BREAK_CHARACTER}`, { bold: true })
+          .insert('\n'),
       );
       // importantly deleting the character after a soft break, such that the soft break becomes
       // the last leaf in the block, should add the trailing break
-      expect(editor.scroll.domNode).toEqualHTML('<p><strong>0<br class="soft-break" /></strong><br></p>',);
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<p><strong>0<br class="soft-break" /></strong><br></p>',
+      );
     });
 
     test('entire document', () => {

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -190,11 +190,11 @@ describe('Editor', () => {
       editor.insertText(4, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
         new Delta()
-          .insert('0123', { bold: true })
-          .insert(`${SOFT_BREAK_CHARACTER}\n`),
+          .insert(`0123${SOFT_BREAK_CHARACTER}`, { bold: true })
+          .insert('\n'),
       );
       expect(editor.scroll.domNode).toEqualHTML(`
-        <p><strong>0123</strong><br class="soft-break"><br></p>`);
+        <p><strong>0123<br class="soft-break"></strong><br></p>`);
     });
 
     test('multiline text', () => {
@@ -239,6 +239,20 @@ describe('Editor', () => {
       editor.insertText(2, '23', { bold: false, strike: false });
       expect(editor.getDelta()).toEqual(
         new Delta().insert('01', { strike: true }).insert('23\n'),
+      );
+    });
+
+    test('formatted text at the end of a block that ends with other format', () => {
+      const editor = createEditor('<p><strong>01</strong></p>');
+      editor.insertText(2, 'example', { link: 'http://example.com' });
+      expect(editor.getDelta()).toEqual(
+        new Delta()
+          .insert('01', { bold: true })
+          .insert('example', { link: 'http://example.com', bold: true })
+          .insert('\n'),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<p><strong>01<a rel="noopener noreferrer" target="_blank" href="http://example.com">example</a></strong></p>',
       );
     });
   });

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -161,7 +161,7 @@ describe('Editor', () => {
         <p><br></p>`);
     });
 
-    test('insert soft line', () => {
+    test('insert soft line break', () => {
       const editor = createEditor('<p><strong>0123</strong></p>');
       editor.insertText(3, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
@@ -173,7 +173,7 @@ describe('Editor', () => {
         <p><strong>012<br class="soft-break">3</strong></p>`);
     });
 
-    test('append soft line', () => {
+    test('append soft line break', () => {
       const editor = createEditor('<ol><li data-list="bullet">0123</li></ol>');
       editor.insertText(4, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
@@ -183,6 +183,18 @@ describe('Editor', () => {
       );
       expect(editor.scroll.domNode).toEqualHTML(`
         <ol><li data-list="bullet">0123<br class="soft-break" /><br /></li></ol>`);
+    });
+
+    test('append soft line break in format', () => {
+      const editor = createEditor('<p><strong>0123</strong></p>');
+      editor.insertText(4, SOFT_BREAK_CHARACTER);
+      expect(editor.getDelta()).toEqual(
+        new Delta()
+          .insert('0123', { bold: true })
+          .insert(`${SOFT_BREAK_CHARACTER}\n`),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(`
+        <p><strong>0123</strong><br class="soft-break"><br></p>`);
     });
 
     test('multiline text', () => {
@@ -268,7 +280,7 @@ describe('Editor', () => {
       expect(editor.scroll.domNode).toEqualHTML('<p><em>01235678</em></p>');
     });
 
-    test('soft line', () => {
+    test('soft line break at end of bold text', () => {
       const editor = createEditor(
         '<p><strong>0123<br class="soft-break" /></strong><br /></p>',
       );
@@ -277,6 +289,32 @@ describe('Editor', () => {
         new Delta().insert('0123', { bold: true }).insert('\n'),
       );
       expect(editor.scroll.domNode).toEqualHTML('<p><strong>0123</strong></p>');
+    });
+
+    test('text before soft line break', () => {
+      const editor = createEditor(
+        '<p>0<br class="soft-break" />1</p>',
+      );
+      editor.deleteText(2, 1);
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`0${SOFT_BREAK_CHARACTER}`).insert('\n'),
+      );
+      // importantly deleting the character after a soft break, such that the soft break becomes
+      // the last leaf in the block, should add the trailing break
+      expect(editor.scroll.domNode).toEqualHTML('<p>0<br class="soft-break" /><br /></p>');
+    });
+
+    test('text before soft line break within an inline parent', () => {
+      const editor = createEditor(
+        '<p><strong>0<br class="soft-break" />1</strong></p>',
+      );
+      editor.deleteText(2, 1);
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`0${SOFT_BREAK_CHARACTER}`, {bold: true}).insert('\n'),
+      );
+      // importantly deleting the character after a soft break, such that the soft break becomes
+      // the last leaf in the block, should add the trailing break
+      expect(editor.scroll.domNode).toEqualHTML('<p><strong>0<br class="soft-break" /></strong><br></p>',);
     });
 
     test('entire document', () => {
@@ -305,7 +343,7 @@ describe('Editor', () => {
       expect(editor.scroll.domNode).toEqualHTML('<h1>0123</h1>');
     });
 
-    test('soft line', () => {
+    test('soft line break', () => {
       const editor = createEditor('<p>01<br class="soft-break" />23</p>');
       editor.formatLine(0, 1, { header: 1 });
       expect(editor.getDelta()).toEqual(
@@ -342,7 +380,7 @@ describe('Editor', () => {
       expect(editor.scroll.domNode).toEqualHTML('<p>01</p><p>34</p>');
     });
 
-    test('soft line', () => {
+    test('soft line break', () => {
       const editor = createEditor(
         '<p><strong>01<br class="soft-break" />23</strong></p>',
       );
@@ -450,7 +488,7 @@ describe('Editor', () => {
       expect(editor.scroll.domNode).toEqualHTML('<p>01</p><h1><br></h1>');
     });
 
-    test('insert soft line at end of block', () => {
+    test('insert soft line break at end of block', () => {
       const editor = createEditor(
         `<ol>
           <li data-list="ordered">0</li>
@@ -477,7 +515,7 @@ describe('Editor', () => {
       );
     });
 
-    test('insert soft line in middle of block', () => {
+    test('insert soft line break in middle of block', () => {
       const editor = createEditor(
         `<ol>
           <li data-list="ordered">01</li>

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -27,6 +27,7 @@ import IndentClass from '../../../src/formats/indent.js';
 import { ColorClass } from '../../../src/formats/color.js';
 import Quill from '../../../src/core.js';
 import { normalizeHTML } from '../__helpers__/utils.js';
+import SoftBreak, { SOFT_BREAK_CHARACTER } from '../../../src/blots/soft-break.js';
 
 const createEditor = (html: string) => {
   const container = document.createElement('div');
@@ -52,6 +53,7 @@ const createEditor = (html: string) => {
       CodeBlockContainer,
       Blockquote,
       SizeClass,
+      SoftBreak,
     ]),
   });
   return quill.editor;
@@ -157,6 +159,26 @@ describe('Editor', () => {
         <p><br></p>`);
     });
 
+    test('insert soft line', () => {
+      const editor = createEditor('<p><strong>0123</strong></p>');
+      editor.insertText(3, SOFT_BREAK_CHARACTER);
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`012${SOFT_BREAK_CHARACTER}3`, { bold: true }).insert('\n'),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(`
+        <p><strong>012<br class="soft-break">3</strong></p>`);
+    });
+
+    test('append soft line', () => {
+      const editor = createEditor('<ol><li data-list="bullet">0123</li></ol>');
+      editor.insertText(4, SOFT_BREAK_CHARACTER);
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`0123${SOFT_BREAK_CHARACTER}`).insert('\n', {list: "bullet"}),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(`
+        <ol><li data-list="bullet">0123<br class="soft-break" /><br /></li></ol>`);
+    });
+
     test('multiline text', () => {
       const editor = createEditor('<p><strong>0123</strong></p>');
       editor.insertText(2, '\n!!\n!!\n');
@@ -240,6 +262,13 @@ describe('Editor', () => {
       expect(editor.scroll.domNode).toEqualHTML('<p><em>01235678</em></p>');
     });
 
+    test('soft line', () => {
+      const editor = createEditor('<p><strong>0123<br class="soft-break" /></strong><br /></p>');
+      editor.deleteText(4, 1);
+      expect(editor.getDelta()).toEqual(new Delta().insert('0123', {bold: true}).insert('\n'));
+      expect(editor.scroll.domNode).toEqualHTML('<p><strong>0123</strong></p>');
+    });
+
     test('entire document', () => {
       const editor = createEditor('<p><strong><em>0123</em></strong></p>');
       editor.deleteText(0, 5);
@@ -265,6 +294,15 @@ describe('Editor', () => {
       editor.formatLine(1, 1, { header: 1 });
       expect(editor.scroll.domNode).toEqualHTML('<h1>0123</h1>');
     });
+
+    test('soft line', () => {
+      const editor = createEditor('<p>01<br class="soft-break" />23</p>');
+      editor.formatLine(0, 1, {header: 1})
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`01${SOFT_BREAK_CHARACTER}23`).insert('\n', {header: 1}),
+      );
+      expect(editor.scroll.domNode).toEqualHTML('<h1>01<br class="soft-break" />23</h1>')
+    });
   });
 
   describe('removeFormat', () => {
@@ -288,6 +326,15 @@ describe('Editor', () => {
       );
       editor.removeFormat(1, 3);
       expect(editor.scroll.domNode).toEqualHTML('<p>01</p><p>34</p>');
+    });
+
+    test('soft line', () => {
+      const editor = createEditor('<p><strong>01<br class="soft-break" />23</strong></p>');
+      editor.removeFormat(0, 2)
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert('01').insert(`${SOFT_BREAK_CHARACTER}23`, {bold: true}).insert('\n'),
+      );
+      expect(editor.scroll.domNode).toEqualHTML('<p>01<strong><br class="soft-break" />23</strong></p>')
     });
 
     test('remove embed', () => {
@@ -380,6 +427,50 @@ describe('Editor', () => {
       const editor = createEditor('<h1>01</h1>');
       editor.applyDelta(new Delta().retain(2).insert('\n'));
       expect(editor.scroll.domNode).toEqualHTML('<p>01</p><h1><br></h1>');
+    });
+
+    test('insert soft line at end of block', () => {
+      const editor = createEditor(
+        `<ol>
+          <li data-list="ordered">0</li>
+          <li data-list="ordered">1</li>
+        </ol>`
+      );
+      editor.applyDelta(new Delta().retain(3).insert(SOFT_BREAK_CHARACTER));
+      expect(editor.getDelta()).toEqual(
+        new Delta()
+          .insert('0')
+          .insert('\n', {list: 'ordered'})
+          .insert(`1${SOFT_BREAK_CHARACTER}`)
+          .insert('\n', {list: 'ordered'})
+      );
+      expect(editor.scroll.domNode).toEqualHTML(
+        `<ol>
+          <li data-list="ordered">0</li>
+          <li data-list="ordered">
+            1
+            <br class="soft-break"/>
+            <br />
+          </li>
+        </ol>`
+      );
+    });
+
+    test('insert soft line in middle of block', () => {
+      const editor = createEditor(
+        `<ol>
+          <li data-list="ordered">01</li>
+        </ol>`
+      );
+      editor.applyDelta(new Delta().retain(1).insert(SOFT_BREAK_CHARACTER));
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`0${SOFT_BREAK_CHARACTER}1`).insert('\n', {list: 'ordered'})
+      );
+      expect(editor.scroll.domNode).toEqualHTML(
+        `<ol>
+          <li data-list="ordered">0<br class="soft-break">1</li>
+        </ol>`
+      );
     });
 
     test('formatted embed', () => {

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -27,7 +27,9 @@ import IndentClass from '../../../src/formats/indent.js';
 import { ColorClass } from '../../../src/formats/color.js';
 import Quill from '../../../src/core.js';
 import { normalizeHTML } from '../__helpers__/utils.js';
-import SoftBreak, { SOFT_BREAK_CHARACTER } from '../../../src/blots/soft-break.js';
+import SoftBreak, {
+  SOFT_BREAK_CHARACTER,
+} from '../../../src/blots/soft-break.js';
 
 const createEditor = (html: string) => {
   const container = document.createElement('div');
@@ -163,7 +165,9 @@ describe('Editor', () => {
       const editor = createEditor('<p><strong>0123</strong></p>');
       editor.insertText(3, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
-        new Delta().insert(`012${SOFT_BREAK_CHARACTER}3`, { bold: true }).insert('\n'),
+        new Delta()
+          .insert(`012${SOFT_BREAK_CHARACTER}3`, { bold: true })
+          .insert('\n'),
       );
       expect(editor.scroll.domNode).toEqualHTML(`
         <p><strong>012<br class="soft-break">3</strong></p>`);
@@ -173,7 +177,9 @@ describe('Editor', () => {
       const editor = createEditor('<ol><li data-list="bullet">0123</li></ol>');
       editor.insertText(4, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
-        new Delta().insert(`0123${SOFT_BREAK_CHARACTER}`).insert('\n', {list: "bullet"}),
+        new Delta()
+          .insert(`0123${SOFT_BREAK_CHARACTER}`)
+          .insert('\n', { list: 'bullet' }),
       );
       expect(editor.scroll.domNode).toEqualHTML(`
         <ol><li data-list="bullet">0123<br class="soft-break" /><br /></li></ol>`);
@@ -263,9 +269,13 @@ describe('Editor', () => {
     });
 
     test('soft line', () => {
-      const editor = createEditor('<p><strong>0123<br class="soft-break" /></strong><br /></p>');
+      const editor = createEditor(
+        '<p><strong>0123<br class="soft-break" /></strong><br /></p>',
+      );
       editor.deleteText(4, 1);
-      expect(editor.getDelta()).toEqual(new Delta().insert('0123', {bold: true}).insert('\n'));
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert('0123', { bold: true }).insert('\n'),
+      );
       expect(editor.scroll.domNode).toEqualHTML('<p><strong>0123</strong></p>');
     });
 
@@ -297,11 +307,15 @@ describe('Editor', () => {
 
     test('soft line', () => {
       const editor = createEditor('<p>01<br class="soft-break" />23</p>');
-      editor.formatLine(0, 1, {header: 1})
+      editor.formatLine(0, 1, { header: 1 });
       expect(editor.getDelta()).toEqual(
-        new Delta().insert(`01${SOFT_BREAK_CHARACTER}23`).insert('\n', {header: 1}),
+        new Delta()
+          .insert(`01${SOFT_BREAK_CHARACTER}23`)
+          .insert('\n', { header: 1 }),
       );
-      expect(editor.scroll.domNode).toEqualHTML('<h1>01<br class="soft-break" />23</h1>')
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<h1>01<br class="soft-break" />23</h1>',
+      );
     });
   });
 
@@ -329,12 +343,19 @@ describe('Editor', () => {
     });
 
     test('soft line', () => {
-      const editor = createEditor('<p><strong>01<br class="soft-break" />23</strong></p>');
-      editor.removeFormat(0, 2)
-      expect(editor.getDelta()).toEqual(
-        new Delta().insert('01').insert(`${SOFT_BREAK_CHARACTER}23`, {bold: true}).insert('\n'),
+      const editor = createEditor(
+        '<p><strong>01<br class="soft-break" />23</strong></p>',
       );
-      expect(editor.scroll.domNode).toEqualHTML('<p>01<strong><br class="soft-break" />23</strong></p>')
+      editor.removeFormat(0, 2);
+      expect(editor.getDelta()).toEqual(
+        new Delta()
+          .insert('01')
+          .insert(`${SOFT_BREAK_CHARACTER}23`, { bold: true })
+          .insert('\n'),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<p>01<strong><br class="soft-break" />23</strong></p>',
+      );
     });
 
     test('remove embed', () => {
@@ -434,15 +455,15 @@ describe('Editor', () => {
         `<ol>
           <li data-list="ordered">0</li>
           <li data-list="ordered">1</li>
-        </ol>`
+        </ol>`,
       );
       editor.applyDelta(new Delta().retain(3).insert(SOFT_BREAK_CHARACTER));
       expect(editor.getDelta()).toEqual(
         new Delta()
           .insert('0')
-          .insert('\n', {list: 'ordered'})
+          .insert('\n', { list: 'ordered' })
           .insert(`1${SOFT_BREAK_CHARACTER}`)
-          .insert('\n', {list: 'ordered'})
+          .insert('\n', { list: 'ordered' }),
       );
       expect(editor.scroll.domNode).toEqualHTML(
         `<ol>
@@ -452,7 +473,7 @@ describe('Editor', () => {
             <br class="soft-break"/>
             <br />
           </li>
-        </ol>`
+        </ol>`,
       );
     });
 
@@ -460,16 +481,18 @@ describe('Editor', () => {
       const editor = createEditor(
         `<ol>
           <li data-list="ordered">01</li>
-        </ol>`
+        </ol>`,
       );
       editor.applyDelta(new Delta().retain(1).insert(SOFT_BREAK_CHARACTER));
       expect(editor.getDelta()).toEqual(
-        new Delta().insert(`0${SOFT_BREAK_CHARACTER}1`).insert('\n', {list: 'ordered'})
+        new Delta()
+          .insert(`0${SOFT_BREAK_CHARACTER}1`)
+          .insert('\n', { list: 'ordered' }),
       );
       expect(editor.scroll.domNode).toEqualHTML(
         `<ol>
           <li data-list="ordered">0<br class="soft-break">1</li>
-        </ol>`
+        </ol>`,
       );
     });
 

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -359,19 +359,21 @@ describe('Clipboard', () => {
       ],
       [
         '<p><strong><em>a</em><br></strong><br></p>',
-        new Delta().insert('a', {
-          bold: true,
-          italic: true,
-        })
-        .insert(`${SOFT_BREAK_CHARACTER}`, {bold: true}),
+        new Delta()
+          .insert('a', {
+            bold: true,
+            italic: true,
+          })
+          .insert(`${SOFT_BREAK_CHARACTER}`, { bold: true }),
       ],
       [
         '<p><strong><em>a</em></strong><br><br></p>',
-        new Delta().insert('a', {
-          bold: true,
-          italic: true,
-        })
-        .insert(`${SOFT_BREAK_CHARACTER}`),
+        new Delta()
+          .insert('a', {
+            bold: true,
+            italic: true,
+          })
+          .insert(`${SOFT_BREAK_CHARACTER}`),
       ],
     ];
     for (let [html, expectedDelta] of softBreaksCases) {

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -376,7 +376,7 @@ describe('Clipboard', () => {
           .insert(`${SOFT_BREAK_CHARACTER}`),
       ],
     ];
-    for (let [html, expectedDelta] of softBreaksCases) {
+    for (const [html, expectedDelta] of softBreaksCases) {
       test(`breaks matching for nested formats ${html}`, () => {
         const delta = createClipboard().convert({ html });
         expect(delta).toEqual(expectedDelta);


### PR DESCRIPTION
This PR proposes to add the ability to insert "soft" line breaks. A "soft" line break is defined as a line break that continues the current block formatting. 

So, to use markdown as an example, the first bullet point here includes a soft line break, whereas there is a hard line break between the first and second bullet blocks: 
- this is
the first bullet block
- this is the second bullet block

This implementation represents soft breaks in 2 ways:
- in the data layer, soft breaks are represented in `Delta`s as regular text, with each soft break being a single `\u2028` character. This character was chosen because a line break within a paragraph seems to be its intended use (see https://codepoints.net/U+2028?lang=en), and given this character exists, a special case embed insert shape for soft line breaks is not necessary in a Delta. Using a character also allows for inserts to be combined more often, resulting in less duplication of attributes, and less overall operations for the same delta. This mirrors the use of `\n` in `Delta`s to represent hard line breaks.
- in the view layer, soft breaks are represented as `<br class="soft-break" />`. 

So, for example, the Delta: 
```js
[{insert: "Hello\u2028World"}, {insert: "\n", attributes: {list: 'ordered'}}]
``` 
would be rendered as:
```html
<ol>
  <li data-list="ordered">
    Hello
    <br class="soft-break">
    World
   </li>
</ol>
```

In order to represent soft breaks as `<br class="soft-break" />` in the DOM, this implementation introduces a new `SoftBreak` blot, and changes the definition of the existing `Break` blot. The existing `Break` blot is still a zero-length blot that exists only for rendering purposes. The current `Break` blot is only rendered when a block is empty. This PR changes that to also include the case when a block ends with a soft break. This allows a soft break at the end of a block to be properly rendered, since the browser always ignores an "end of line-breaking element" `<br />` tag.


This PR also adds a keyboard binding of SHIFT+ENTER to insert a soft line break. This keyboard binding is consistent with many text editors and with many of the feature request issues made on this subject.