### PR TITLE
Feature: Specifying source for undo / redo

### DIFF
--- a/packages/quill/src/modules/history.ts
+++ b/packages/quill/src/modules/history.ts
@@ -94,7 +94,7 @@ class History extends Module<HistoryOptions> {
     });
     this.lastRecorded = 0;
     this.ignoreChange = true;
-    this.quill.updateContents(item.delta, Quill.sources.USER);
+    this.quill.updateContents(item.delta, source);
     this.ignoreChange = false;
 
     this.restoreSelection(item);


### PR DESCRIPTION
### Summary
This pull request refactors the undo/redo methods to allow you to specify a source. The following changes were made:

- Renamed parameters for the `change` method from `source` and `dest` to `sourceStack` and `destStack.`
- Added new `source` parameter for the `change` method with the `EmitterSource` type.
- Refactored `undo` and `redo` methods to leverage the updated `change` method while maintaining backward compatibility.

### Motivation
These changes make the undo/redo methods more flexible, particularly in cases where you want to undo or redo actions while user interaction is disabled.

### Testing
- Verified that undo/redo functionality behaves as expected in the editor.
- Confirmed backward compatibility with existing workflows.

Please review the changes and let me know if any adjustments are needed. Also this is my first ever PR so apologizes if I have done anything wrong.
