### PR TITLE
Decide whether or not Quill will handle the copy event THEN preventDefault.

### DIFF
--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -170,9 +170,9 @@ class Clipboard extends Module<ClipboardOptions> {
 
   onCaptureCopy(e: ClipboardEvent, isCut = false) {
     if (e.defaultPrevented) return;
-    e.preventDefault();
     const [range] = this.quill.selection.getRange();
     if (range == null) return;
+    e.preventDefault();
     const { html, text } = this.onCopy(range, isCut);
     e.clipboardData?.setData('text/plain', text);
     e.clipboardData?.setData('text/html', html);


### PR DESCRIPTION
Resolves #4572 

The issue was an order of operations. Whenever the clipboard module captures a copy event it calls `preventDefault()` on it **before it actually decides to do anything with the event**.

This PR just moves the call to `preventDefault()` after the clipboard module decides to handle it.

In the case where the user selects the contents before, including, and after the quill root, the `onCopyCapture` handler doesn't get called, because some parent node handles the copy event.

In the case where the user selects only text within the quill root, `this.quill.selection.getRange()` is able to return a valid range.

However in cases where selection goes off the end of the quill root `this.quill.selection.getRange()` returns `null`, resulting in a copy handler that prevents default AND doesn't handle the copy.