### PR TITLE
Revert replacing all spaces with NBSP

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -371,7 +371,7 @@ function convertHTML(
   }
   if (blot instanceof TextBlot) {
     const escapedText = escapeText(blot.value().slice(index, index + length));
-    return escapedText.replaceAll(' ', '&nbsp;');
+    return escapedText;
   }
   if (blot instanceof ParentBlot) {
     // TODO fix API


### PR DESCRIPTION
Fixes an issue where all spaces in text blot were being converted to non breaking spaces, which is not WYSIWYG.