### PR TITLE
Add getSemanticHTML options & Add preserveWhitespace option to getSem…

### DIFF
--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -35,6 +35,12 @@ export class Range {
   ) {}
 }
 
+export function isRange(value: any): value is Range {
+  return (
+    value && typeof value === 'object' && 'index' in value && 'length' in value
+  );
+}
+
 class Selection {
   scroll: Scroll;
   emitter: Emitter;

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1281,6 +1281,7 @@ describe('Editor', () => {
           </ol>
         `,
       );
+      
       expect(editor.getHTML(2, 12)).toEqualHTML(`
         <ol>
           <li>e</li>
@@ -1408,6 +1409,18 @@ describe('Editor', () => {
       expect(editor.getHTML(1, 7)).toEqual('<pre>\n0123\n\n\n\n</pre>');
       expect(editor.getHTML(2, 7)).toEqual('<pre>\n123\n\n\n4\n</pre>');
       expect(editor.getHTML(5, 7)).toEqual('<pre>\n\n\n\n4567\n</pre>');
+    });
+
+    test('option preserveWhitespace is disabled (DEFAULT)', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14)).toEqual('<p>This&nbsp;is&nbsp;Quill</p>');
+    });
+
+    test('option preserveWhitespace is enabled', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14, { preserveWhitespace: true })).toEqual(
+        '<p>This is Quill</p>',
+      );
     });
   });
 });

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -604,9 +604,33 @@ describe('Quill', () => {
 
     test('works with range', () => {
       const quill = new Quill(createContainer('<h1>Welcome</h1>'));
-      expect(quill.getText({ index: 1, length: 2 })).toMatchInlineSnapshot(
-        '"el"',
-      );
+      expect(
+        quill.getSemanticHTML({ index: 1, length: 2 }),
+      ).toMatchInlineSnapshot('"el"');
+    });
+
+    test('works with only options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML({ preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index, length and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, 10, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "Welcome to"
+      `);
     });
   });
 

--- a/packages/website/content/docs/api.mdx
+++ b/packages/website/content/docs/api.mdx
@@ -116,10 +116,14 @@ This method is useful for exporting the contents of the editor in a format that 
 
 The `length` parameter defaults to the length of the remaining document.
 
+The `options` parameter allows to modify output:
+
+- `preserveWhitespace` - if true all whitespaces are preserved, otherwise all whitespaces are changed to `"&nbsp;"` (default: false)
+
 **Methods**
 
 ```typescript
-getSemanticHTML(index: number = 0, length: number = remaining): string
+getSemanticHTML(index: number = 0, length: number = remaining, options?: SemanticHTMLOptions): string
 ```
 
 **Examples**


### PR DESCRIPTION
As many people, I was also using quill for it HTML content, so it can be displayed somewhere else. 

The addition of conversion from whitespace to `&nbsp;` was needed for consecutive copying and pasting, so my proposition is to add options object that can be extended for other cases. For now, I added `preserveWhitespace` that preserve all whitespaces if true, otherwise all whitespaces are changed to `&nbsp;` (default: false).

I hope that this can be a middle ground between pushing **Quill** forward and providing compatibility for all people using it for a long time.