### PR TITLE
fix: paste `th` should as a line like `td`

### DIFF
--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -350,6 +350,7 @@ function isLine(node: Node, scroll: ScrollBlot) {
     'table',
     'td',
     'tr',
+    'th',
     'ul',
     'video',
   ].includes(node.tagName.toLowerCase());


### PR DESCRIPTION
### Description

when there are consecutive 'th' in the pasted table, the pasted 'th' will be merged.

I checked the source code and found that 'th' was not parsed as a line like 'td', so this situation occurred

### Reproduction

paste the table below

<details>
  <summary> paste html </summary>

```html
<table>
  <tbody>
    <tr>
      <th scope="col">Person</th>
      <th scope="col">Most interest in</th>
      <th scope="col">Age</th>
    </tr>
    <tr>
      <th scope="row">Dennis</th>
      <td>Web accessibility</td>
      <td>45</td>
    </tr>
    <tr>
      <th scope="row">Sarah</th>
      <td>JavaScript frameworks</td>
      <td>29</td>
    </tr>
  </tbody>
</table>
```

</details>

### Current Behavior

![image](https://github.com/user-attachments/assets/ef1bf99f-c2c9-4020-8ff1-3f77290de21f)

and the table delta like this 

```js
[
    {
        "insert": "PersonMost interest inAge\n",
        "attributes": {
            "table": 1
        }
    },
    {
        "insert": "Dennis\nWeb accessibility\n45\n",
        "attributes": {
            "table": 2
        }
    },
    {
        "insert": "Sarah\nJavaScript frameworks\n29\n",
        "attributes": {
            "table": 3
        }
    }
]
```

### Expected Behavior

![image](https://github.com/user-attachments/assets/4b29f68e-9277-4c27-9208-3a419dc94975)

the correct table delta should be like this

```js
[
    {
        "insert": "Person\nMost interest in\nAge\n",
        "attributes": {
            "table": 1
        }
    },
    {
        "insert": "Dennis\nWeb accessibility\n45\n",
        "attributes": {
            "table": 2
        }
    },
    {
        "insert": "Sarah\nJavaScript frameworks\n29\n",
        "attributes": {
            "table": 3
        }
    }
]
```

### Additional comments

I have my own quill table module plugin that provides many table related operations. but I found this issue when I paste `th` tag into editor. there is a lot of code related to 'isLine' that has not been exposed to the outside, so I am unable to hack it.

