### PR TITLE
fix: `getFormat` get wrong format when `BlockEmbed` in range

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -8,6 +8,7 @@ import CursorBlot from '../blots/cursor.js';
 import type Scroll from '../blots/scroll.js';
 import TextBlot, { escapeText } from '../blots/text.js';
 import { Range } from './selection.js';
+import { Parchment } from './quill.js';
 
 const ASCII = /^[ -~]*$/;
 
@@ -173,13 +174,20 @@ class Editor {
         const [blot] = path;
         if (blot instanceof Block) {
           lines.push(blot);
-        } else if (blot instanceof LeafBlot) {
+        } else if (blot instanceof LeafBlot && !(blot instanceof BlockEmbed)) {
           leaves.push(blot);
         }
       });
     } else {
-      lines = this.scroll.lines(index, length);
-      leaves = this.scroll.descendants(LeafBlot, index, length);
+      lines = this.scroll
+        .lines(index, length)
+        .filter((line) => !(line instanceof BlockEmbed));
+      leaves = this.scroll.descendants(
+        (blot: Parchment.Blot) =>
+          blot instanceof Parchment.LeafBlot && !(blot instanceof BlockEmbed),
+        index,
+        length,
+      ) as Parchment.LeafBlot[];
     }
     const [lineFormats, leafFormats] = [lines, leaves].map((blots) => {
       const blot = blots.shift();

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1219,6 +1219,35 @@ describe('Editor', () => {
         align: ['right', 'center'],
       });
     });
+
+    test('Embed in range', () => {
+      const editor = createEditor(
+        `
+          <h1 class="ql-align-right"><em>01</em></h1>
+          <img src="#" />
+          <h1 class="ql-align-center"><em>34</em></h1>
+        `,
+      );
+      expect(editor.getFormat(1, 3)).toEqual({
+        italic: true,
+        header: 1,
+        align: ['right', 'center'],
+      });
+    });
+    test('BlockEmbed in range', () => {
+      const editor = createEditor(
+        `
+          <h1 class="ql-align-right"><em>01</em></h1>
+          <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+          <h1 class="ql-align-center"><em>34</em></h1>
+        `,
+      );
+      expect(editor.getFormat(1, 3)).toEqual({
+        italic: true,
+        header: 1,
+        align: ['right', 'center'],
+      });
+    });
   });
 
   describe('getHTML', () => {

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1224,7 +1224,7 @@ describe('Editor', () => {
       const editor = createEditor(
         `
           <h1 class="ql-align-right"><em>01</em></h1>
-          <img src="#" />
+          <h1 class="ql-align-right"><em><img src="#" /></em></h1>
           <h1 class="ql-align-center"><em>34</em></h1>
         `,
       );


### PR DESCRIPTION
[demo](https://quilljs.com/playground/snow#codeN4Ig9AlgdgJgpgDwHQAsAuBbANiAXCAHgCMBXNNAeygAIIYBeAHRCLSmYD4BzONagMwoAnDAEM0BMKXJUOjKARgQAbrQbM4SykM6SlyuewUBnAMZCIABz7GhppuGjxkAK2O6wZi9Y4gANI6wiEhueCCmVMZ8AI4kEFhY1PTUUHAA7tQAinEJABQA5ADEmhDa+X7UwPLU1BgUMCRYcMa4ldU11JQUWESiQq0A2u0d1APA1ChwovD9owCMFQBMFfyiWMZwALrUAL6bfsMdA-lE3TDl1PnKdHAUF-mlaxCm9yRBQljQcPn7hzXHEDEPHuEXgAFoiFgKKYANY-A40Dq-RE7BE1SxYUSmOAoM5wWb5ADCFAwlgoG2oohocEszyQ9PK7TQkwwcFa+WMUAoaQuYDA1GEl1IREh33kOwAlABueTyWLxLBIDZoYlQNBwNXGXJDRE1Kq6kbUZjiNAWaTNZitfWGm1GlhnS2dIQkOB-Dqot01ZjQDZCNCO5hzRYAZiDweYhw9Buttu9UF9-rwdsYspAkbRHRjNrjCcdWdtXpA13gFADIHVUSQEQwEYNIx26cO+ZGxvIZrIFqTzdj9qwMEdppdnt2GezIB9+MTrUDIbDtfro7adY6OcnZZT7DTBobUE2EtlUFYUCQVFMn1hSWouQlSQ4S5q8oSSt4AGU4E1TGgIFRcgAGCpzAALPuiIRPG3RwEgUJcLkj6KjwaAAGLCGIaB-gBwEgTsIA7EAA)

The case in demo, format should return `{ blod: true }` but get `{}`. This is because `BlockEmbed` is included in the calculation of blot. But `BlockEmbed` doesn't have attributes, make the intersection attribute empty.
