### PR TITLE
Fix: Prevent remote updates from ending ongoing local batches

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -28,7 +28,10 @@ class Editor {
   applyDelta(delta: Delta): Delta {
     this.scroll.update();
     let scrollLength = this.scroll.length();
-    this.scroll.batchStart();
+    const isAlreadyBatching = Boolean(this.scroll.batch);
+    if (!isAlreadyBatching) {
+      this.scroll.batchStart();
+    }
     const normalizedDelta = normalizeDelta(delta);
     const deleteDelta = new Delta();
     const normalizedOps = splitOpLines(normalizedDelta.ops.slice());
@@ -117,7 +120,9 @@ class Editor {
       }
       return index + Op.length(op);
     }, 0);
-    this.scroll.batchEnd();
+    if (!isAlreadyBatching) {
+      this.scroll.batchEnd();
+    }
     this.scroll.optimize();
     return this.update(normalizedDelta);
   }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?

- After the fix, characters in the local editor in the unconfirmed state will not be updated to the DOM, and the bug in Quill's use for collaborative editing is resolved


Issue Number: [Using 3-set Korean IME during collaborative editing caused incorrect content synchronization.](https://github.com/slab/quill/issues/4449)



