### PR TITLE
Add ContainerBlot Formatting Support and Optimize Insertion Behavior

### DIFF
--- a/packages/quill/src/blots/scroll.ts
+++ b/packages/quill/src/blots/scroll.ts
@@ -169,8 +169,11 @@ class Scroll extends ScrollBlot {
         this.insertAt(lineEndIndex - 1, '\n');
       }
 
-      const formats = bubbleFormats(this.line(index)[0]);
+      const firstLine = this.line(index)[0];
+      const formats = bubbleFormats(firstLine);
       const attributes = AttributeMap.diff(formats, first.attributes) || {};
+      const firstLineOffset =
+        firstLine?.offset(firstLine.parent || this) || index;
       Object.keys(attributes).forEach((name) => {
         const format = this.scroll.query(name, Scope.BLOCK);
         if (
@@ -180,8 +183,10 @@ class Scroll extends ScrollBlot {
           containerAttributes.push({
             name,
             value: attributes[name],
-            index: lineEndIndex - 1,
-            length: delta.length(),
+            // index: lineEndIndex - 1,
+            index: firstLineOffset,
+            // length: delta.length(),
+            length: lineEndIndex - firstLineOffset,
           });
           return;
         }
@@ -235,7 +240,7 @@ class Scroll extends ScrollBlot {
             cAttributes[i].length = l;
           }
           containerAttributes.push(...cAttributes);
-          blockOffset += l === 0 ? 1 : l;
+          blockOffset += l; // === 0 ? 1 : l;
         } else {
           const blockEmbed = this.create(
             renderBlock.key,

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -1,5 +1,11 @@
 import { cloneDeep, isEqual, merge } from 'lodash-es';
-import { LeafBlot, EmbedBlot, Scope, ParentBlot } from 'parchment';
+import {
+  ContainerBlot,
+  LeafBlot,
+  EmbedBlot,
+  Scope,
+  ParentBlot,
+} from 'parchment';
 import type { Blot } from 'parchment';
 import Delta, { AttributeMap, Op } from 'quill-delta';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block.js';
@@ -32,6 +38,14 @@ class Editor {
     const normalizedDelta = normalizeDelta(delta);
     const deleteDelta = new Delta();
     const normalizedOps = splitOpLines(normalizedDelta.ops.slice());
+
+    const containerAttributes: {
+      name: string;
+      value: unknown;
+      index: number;
+      length?: number;
+    }[] = [];
+
     normalizedOps.reduce((index, op) => {
       const length = Op.length(op);
       let attributes = op.attributes || {};
@@ -101,6 +115,19 @@ class Editor {
         }
       }
       Object.keys(attributes).forEach((name) => {
+        const format = this.scroll.query(name, Scope.BLOCK);
+        if (
+          format != null &&
+          (format as Function).prototype instanceof ContainerBlot
+        ) {
+          containerAttributes.push({
+            name,
+            value: attributes[name],
+            index,
+            length,
+          });
+          return;
+        }
         this.scroll.formatAt(index, length, name, attributes[name]);
       });
       const prependedLength = isImplicitNewlinePrepended ? 1 : 0;
@@ -119,6 +146,11 @@ class Editor {
     }, 0);
     this.scroll.batchEnd();
     this.scroll.optimize();
+
+    containerAttributes.forEach(({ name, value, index, length }) => {
+      this.scroll.formatAt(index, length != null ? length : 1, name, value);
+    });
+
     return this.update(normalizedDelta);
   }
 

--- a/packages/quill/test/unit/modules/table.spec.ts
+++ b/packages/quill/test/unit/modules/table.spec.ts
@@ -457,5 +457,29 @@ describe('Table Module', () => {
       const quill = setupWithHtml(content);
       expect(quill.root.innerHTML).toBe(normalizeHTML(content));
     });
+
+    test.only('updateContents with class names', () => {
+      const quill = setupWithHtml('<p><br></p>');
+      quill.updateContents(
+        new Delta()
+          .retain(quill.getLength())
+          .insert('\n\n', { table: 'row-lo87' })
+          .insert('\n\n', { table: 'row-54yt', 'table-row': 'custom-row' }),
+      );
+      expect(quill.root.innerHTML).toEqualHTML(
+        normalizeHTML(`
+        <p>
+          <br>
+        </p>
+        <table>
+          <tbody>
+            <tr><td><br></td><td><br></td></tr>
+            <tr class="custom-row"><td><br></td><td><br></td></tr>
+          </tbody>
+        </table>
+      `),
+        { ignoreAttrs: ['data-row'] },
+      );
+    });
   });
 });

--- a/packages/quill/test/unit/modules/table.spec.ts
+++ b/packages/quill/test/unit/modules/table.spec.ts
@@ -437,5 +437,25 @@ describe('Table Module', () => {
         { ignoreAttrs: ['data-row'] },
       );
     });
+
+    test('table as first line', () => {
+      const content = `
+        <table class="table">
+          <tbody>
+            <tr>
+              <td data-row="row-4uol">Märkus: Detsembris ei ole Kaarli kirikus palvusi esmaspäeviti, sest kirikus toimuvad kontsertid. Selle asemel palvetame Dominiiklaste kabelis (Müürivahe 33). Ka proov kell 17 sealsamas. Ja 5. jaanuaril 2025 läheb elu edasi Kaarli kirikus.</td>
+            </tr>
+          </tbody>
+        </table>
+        <p><br></p>
+        <p><br></p>
+        <p>Ühispalvus igal esmaspäeval kell 18:00. Enne palvust kell 17:00 lauluproov ja ettevalmistused. Igaüks on teretulnud! Ootame lauljaid juurde!</p>
+        <p>Asukoht: Tallinna Kaarli kirik</p>
+        <p>Korraldaja: EELK Tallinna Kaarli kogudus</p>
+        <p>Kontakt: Annely Neame (5267825)</p>
+        <p>N.B.: Juulis, augustis ja detsembris Kaarli kirikus palvusi esmaspäeviti ei ole.</p>`;
+      const quill = setupWithHtml(content);
+      expect(quill.root.innerHTML).toBe(normalizeHTML(content));
+    });
   });
 });


### PR DESCRIPTION
This PR introduces enhanced formatting behavior for `ContainerBlot` and improves how formatting is applied during blot insertion. These changes ensure better compatibility with nested container structures and allow formats to be propagated and applied more consistently across complex document trees.

Look at the changes contained in the [PR on parchment](https://github.com/slab/parchment/pull/157).

Key Improvements
1. `ContainerBlot` Formatting Support

Enables `ContainerBlot` to accept and apply formatting.

Ensures that formats defined on parent blots are properly inherited.

Implementation detail

1. Collects Formats During Insertion

Ensures format data is preserved and passed appropriately during blot creation.

2. Post-Insertion Formatting Application

Calls `formatAt` only after all insertion logic is completed.

Prevents partial formatting application and resolves edge cases involving nested structures. For example when the containers are NOT ready yet and becomes ready through call to `optimize` method.

3. Parchment Updates

Adjusts Parchment logic to correctly interpret and apply `ContainerBlot`-level formats. See the parchment PR detail mentioned above.

Extends format resolution behavior so that container-level formatting is recognized alongside inline and block formats.

Related Issue

This addresses formatting consistency issues similar to those described in:
https://github.com/slab/quill/issues/4750

Why This Matters

These changes improve correctness and flexibility when working with complex container elements, making formatting behavior more predictable and bringing Quill closer to expected behavior in real-world rich-text editing scenarios.

Testing

Verified formatting propagation during nested container insertion.

Confirmed proper execution order of insertion → formatting.

Ensured backward compatibility with existing blots and custom formats.

Test cases related to this pr depends on the changes reflected on the [PR on parchment](https://github.com/slab/parchment/pull/157).