### PR TITLE
feat(security): add Trusted Types support

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -10,7 +10,8 @@
     "eventemitter3": "^5.0.1",
     "lodash-es": "^4.17.21",
     "parchment": "^3.0.0",
-    "quill-delta": "^5.1.0"
+    "quill-delta": "^5.1.0",
+    "safevalues": "^1.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -207,7 +207,7 @@ class Quill {
     }
     const html = this.container.innerHTML.trim();
     this.container.classList.add('ql-container');
-    this.container.innerHTML = '';
+    this.container.textContent = '';
     instances.set(this.container, this);
     this.root = this.addContainer('ql-editor');
     this.root.classList.add('ql-blank');

--- a/packages/quill/src/core/utils/html.ts
+++ b/packages/quill/src/core/utils/html.ts
@@ -24,12 +24,7 @@ function getPolicy(): TrustedTypePolicy | null {
   return quillPolicy;
 }
 
-export function setTrustedInnerHtml(element: HTMLElement, html: string) {
-  const policy = getPolicy();
-  const content = policy ? (policy.createHTML(html) as string) : html;
-  // @ts-expect-error innerHTML accepts TrustedHTML in modern browsers
-  element.innerHTML = content;
-}
+
 
 export function parseHTML(html: string): Document {
   const policy = getPolicy();

--- a/packages/quill/src/core/utils/html.ts
+++ b/packages/quill/src/core/utils/html.ts
@@ -1,0 +1,39 @@
+interface TrustedTypePolicy {
+  createHTML(s: string): unknown;
+}
+
+let quillPolicy: TrustedTypePolicy | null | undefined;
+
+function getPolicy(): TrustedTypePolicy | null {
+  if (quillPolicy === undefined) {
+    quillPolicy = null;
+    if (
+      typeof window !== 'undefined' &&
+      window.trustedTypes &&
+      window.trustedTypes.createPolicy
+    ) {
+      try {
+        quillPolicy = window.trustedTypes.createPolicy('quill', {
+          createHTML: (s: string) => s,
+        });
+      } catch (e) {
+        // Fallback or ignore if policy creation fails
+      }
+    }
+  }
+  return quillPolicy;
+}
+
+export function setTrustedInnerHtml(element: HTMLElement, html: string) {
+  const policy = getPolicy();
+  const content = policy ? (policy.createHTML(html) as string) : html;
+  // @ts-expect-error innerHTML accepts TrustedHTML in modern browsers
+  element.innerHTML = content;
+}
+
+export function parseHTML(html: string): Document {
+  const policy = getPolicy();
+  const content = policy ? (policy.createHTML(html) as string) : html;
+  // @ts-expect-error parseFromString accepts TrustedHTML in modern browsers
+  return new DOMParser().parseFromString(content, 'text/html');
+}

--- a/packages/quill/src/formats/image.ts
+++ b/packages/quill/src/formats/image.ts
@@ -1,5 +1,6 @@
 import { EmbedBlot } from 'parchment';
 import { sanitize } from './link.js';
+import { setElementAttribute } from 'safevalues/dom';
 
 const ATTRIBUTES = ['alt', 'height', 'width'];
 
@@ -8,9 +9,9 @@ class Image extends EmbedBlot {
   static tagName = 'IMG';
 
   static create(value: string) {
-    const node = super.create(value) as Element;
+    const node = super.create(value) as HTMLElement;
     if (typeof value === 'string') {
-      node.setAttribute('src', this.sanitize(value));
+      setElementAttribute(node, 'src', this.sanitize(value));
     }
     return node;
   }

--- a/packages/quill/src/formats/link.ts
+++ b/packages/quill/src/formats/link.ts
@@ -1,4 +1,5 @@
 import Inline from '../blots/inline.js';
+import { setAnchorHref } from 'safevalues/dom';
 
 class Link extends Inline {
   static blotName = 'link';
@@ -7,8 +8,8 @@ class Link extends Inline {
   static PROTOCOL_WHITELIST = ['http', 'https', 'mailto', 'tel', 'sms'];
 
   static create(value: string) {
-    const node = super.create(value) as HTMLElement;
-    node.setAttribute('href', this.sanitize(value));
+    const node = super.create(value) as HTMLAnchorElement;
+    setAnchorHref(node, this.sanitize(value));
     node.setAttribute('rel', 'noopener noreferrer');
     node.setAttribute('target', '_blank');
     return node;
@@ -27,7 +28,7 @@ class Link extends Inline {
       super.format(name, value);
     } else {
       // @ts-expect-error
-      this.domNode.setAttribute('href', this.constructor.sanitize(value));
+      setAnchorHref(this.domNode as HTMLAnchorElement, this.constructor.sanitize(value));
     }
   }
 }

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -23,6 +23,7 @@ import { FontStyle } from '../formats/font.js';
 import { SizeStyle } from '../formats/size.js';
 import { deleteRange } from './keyboard.js';
 import normalizeExternalHTML from './normalizeExternalHTML/index.js';
+import { parseHTML } from '../core/utils/html.js';
 
 const debug = logger('quill:clipboard');
 
@@ -69,39 +70,6 @@ const STYLE_ATTRIBUTORS = [
 
 interface ClipboardOptions {
   matchers: [Selector, Matcher][];
-}
-
-interface TrustedTypePolicy {
-  createHTML(s: string): unknown;
-}
-
-let clipboardPolicy: TrustedTypePolicy | null | undefined;
-
-function getClipboardPolicy(): TrustedTypePolicy | null {
-  if (clipboardPolicy === undefined) {
-    clipboardPolicy = null;
-    if (
-      typeof window !== 'undefined' &&
-      window.trustedTypes &&
-      window.trustedTypes.createPolicy
-    ) {
-      try {
-        clipboardPolicy = window.trustedTypes.createPolicy('quill-clipboard', {
-          createHTML: (s: string) => s,
-        });
-      } catch (e) {
-        // Fallback or ignore if policy creation fails
-      }
-    }
-  }
-  return clipboardPolicy;
-}
-
-function parseHTML(html: string): Document {
-  const policy = getClipboardPolicy();
-  const content = policy ? (policy.createHTML(html) as string) : html;
-  // @ts-expect-error parseFromString accepts TrustedHTML in modern browsers
-  return new DOMParser().parseFromString(content, 'text/html');
 }
 
 class Clipboard extends Module<ClipboardOptions> {

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -71,6 +71,39 @@ interface ClipboardOptions {
   matchers: [Selector, Matcher][];
 }
 
+interface TrustedTypePolicy {
+  createHTML(s: string): unknown;
+}
+
+let clipboardPolicy: TrustedTypePolicy | null | undefined;
+
+function getClipboardPolicy(): TrustedTypePolicy | null {
+  if (clipboardPolicy === undefined) {
+    clipboardPolicy = null;
+    if (
+      typeof window !== 'undefined' &&
+      window.trustedTypes &&
+      window.trustedTypes.createPolicy
+    ) {
+      try {
+        clipboardPolicy = window.trustedTypes.createPolicy('quill-clipboard', {
+          createHTML: (s: string) => s,
+        });
+      } catch (e) {
+        // Fallback or ignore if policy creation fails
+      }
+    }
+  }
+  return clipboardPolicy;
+}
+
+function parseHTML(html: string): Document {
+  const policy = getClipboardPolicy();
+  const content = policy ? (policy.createHTML(html) as string) : html;
+  // @ts-expect-error parseFromString accepts TrustedHTML in modern browsers
+  return new DOMParser().parseFromString(content, 'text/html');
+}
+
 class Clipboard extends Module<ClipboardOptions> {
   static DEFAULTS: ClipboardOptions = {
     matchers: [],
@@ -125,7 +158,7 @@ class Clipboard extends Module<ClipboardOptions> {
   }
 
   protected convertHTML(html: string) {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = parseHTML(html);
     this.normalizeHTML(doc);
     const container = doc.body;
     const nodeMatches = new WeakMap();
@@ -213,7 +246,7 @@ class Clipboard extends Module<ClipboardOptions> {
       return;
     }
     if (html && files.length > 0) {
-      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const doc = parseHTML(html);
       if (
         doc.body.childElementCount === 1 &&
         doc.body.firstElementChild?.tagName === 'IMG'

--- a/packages/quill/src/themes/base.ts
+++ b/packages/quill/src/themes/base.ts
@@ -2,7 +2,8 @@ import { merge } from 'lodash-es';
 import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Theme from '../core/theme.js';
-import { setTrustedInnerHtml } from '../core/utils/html.js';
+import { setElementInnerHtml } from 'safevalues/dom';
+import { sanitizeHtml } from 'safevalues';
 import type { ThemeOptions } from '../core/theme.js';
 import ColorPicker from '../ui/color-picker.js';
 import IconPicker from '../ui/icon-picker.js';
@@ -123,17 +124,17 @@ class BaseTheme extends Theme {
         if (icons[name] == null) return;
         if (name === 'direction') {
           // @ts-expect-error
-          setTrustedInnerHtml(button, icons[name][''] + icons[name].rtl);
+          setElementInnerHtml(button, sanitizeHtml(icons[name][''] + icons[name].rtl));
         } else if (typeof icons[name] === 'string') {
           // @ts-expect-error
-          setTrustedInnerHtml(button, icons[name]);
+          setElementInnerHtml(button, sanitizeHtml(icons[name]));
         } else {
           // @ts-expect-error
           const value = button.value || '';
           // @ts-expect-error
           if (value != null && icons[name][value]) {
             // @ts-expect-error
-            setTrustedInnerHtml(button, icons[name][value]);
+            setElementInnerHtml(button, sanitizeHtml(icons[name][value]));
           }
         }
       });

--- a/packages/quill/src/themes/base.ts
+++ b/packages/quill/src/themes/base.ts
@@ -3,7 +3,7 @@ import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Theme from '../core/theme.js';
 import { setElementInnerHtml } from 'safevalues/dom';
-import { sanitizeHtml } from 'safevalues';
+import { htmlSafeByReview } from 'safevalues/restricted/reviewed';
 import type { ThemeOptions } from '../core/theme.js';
 import ColorPicker from '../ui/color-picker.js';
 import IconPicker from '../ui/icon-picker.js';
@@ -124,17 +124,17 @@ class BaseTheme extends Theme {
         if (icons[name] == null) return;
         if (name === 'direction') {
           // @ts-expect-error
-          setElementInnerHtml(button, sanitizeHtml(icons[name][''] + icons[name].rtl));
+          setElementInnerHtml(button, htmlSafeByReview(icons[name][''] + icons[name].rtl, { justification: 'Bundled SVG icon' }));
         } else if (typeof icons[name] === 'string') {
           // @ts-expect-error
-          setElementInnerHtml(button, sanitizeHtml(icons[name]));
+          setElementInnerHtml(button, htmlSafeByReview(icons[name], { justification: 'Bundled SVG icon' }));
         } else {
           // @ts-expect-error
           const value = button.value || '';
           // @ts-expect-error
           if (value != null && icons[name][value]) {
             // @ts-expect-error
-            setElementInnerHtml(button, sanitizeHtml(icons[name][value]));
+            setElementInnerHtml(button, htmlSafeByReview(icons[name][value], { justification: 'Bundled SVG icon' }));
           }
         }
       });

--- a/packages/quill/src/themes/base.ts
+++ b/packages/quill/src/themes/base.ts
@@ -2,6 +2,7 @@ import { merge } from 'lodash-es';
 import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Theme from '../core/theme.js';
+import { setTrustedInnerHtml } from '../core/utils/html.js';
 import type { ThemeOptions } from '../core/theme.js';
 import ColorPicker from '../ui/color-picker.js';
 import IconPicker from '../ui/icon-picker.js';
@@ -59,6 +60,8 @@ const FONTS = [false, 'serif', 'monospace'];
 const HEADERS = ['1', '2', '3', false];
 
 const SIZES = ['small', false, 'large', 'huge'];
+
+
 
 class BaseTheme extends Theme {
   pickers: Picker[];
@@ -120,17 +123,17 @@ class BaseTheme extends Theme {
         if (icons[name] == null) return;
         if (name === 'direction') {
           // @ts-expect-error
-          button.innerHTML = icons[name][''] + icons[name].rtl;
+          setTrustedInnerHtml(button, icons[name][''] + icons[name].rtl);
         } else if (typeof icons[name] === 'string') {
           // @ts-expect-error
-          button.innerHTML = icons[name];
+          setTrustedInnerHtml(button, icons[name]);
         } else {
           // @ts-expect-error
           const value = button.value || '';
           // @ts-expect-error
           if (value != null && icons[name][value]) {
             // @ts-expect-error
-            button.innerHTML = icons[name][value];
+            setTrustedInnerHtml(button, icons[name][value]);
           }
         }
       });

--- a/packages/quill/src/ui/color-picker.ts
+++ b/packages/quill/src/ui/color-picker.ts
@@ -1,13 +1,13 @@
 import Picker from './picker.js';
 import { setElementInnerHtml } from 'safevalues/dom';
-import { sanitizeHtml } from 'safevalues';
+import { htmlSafeByReview } from 'safevalues/restricted/reviewed';
 
 
 
 class ColorPicker extends Picker {
   constructor(select: HTMLSelectElement, label: string) {
     super(select);
-    setElementInnerHtml(this.label, sanitizeHtml(label));
+    setElementInnerHtml(this.label, htmlSafeByReview(label, { justification: 'Bundled SVG icon or plain text' }));
     this.container.classList.add('ql-color-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item'))
       .slice(0, 7)

--- a/packages/quill/src/ui/color-picker.ts
+++ b/packages/quill/src/ui/color-picker.ts
@@ -1,12 +1,13 @@
 import Picker from './picker.js';
-import { setTrustedInnerHtml } from '../core/utils/html.js';
+import { setElementInnerHtml } from 'safevalues/dom';
+import { sanitizeHtml } from 'safevalues';
 
 
 
 class ColorPicker extends Picker {
   constructor(select: HTMLSelectElement, label: string) {
     super(select);
-    setTrustedInnerHtml(this.label, label);
+    setElementInnerHtml(this.label, sanitizeHtml(label));
     this.container.classList.add('ql-color-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item'))
       .slice(0, 7)

--- a/packages/quill/src/ui/color-picker.ts
+++ b/packages/quill/src/ui/color-picker.ts
@@ -1,9 +1,12 @@
 import Picker from './picker.js';
+import { setTrustedInnerHtml } from '../core/utils/html.js';
+
+
 
 class ColorPicker extends Picker {
   constructor(select: HTMLSelectElement, label: string) {
     super(select);
-    this.label.innerHTML = label;
+    setTrustedInnerHtml(this.label, label);
     this.container.classList.add('ql-color-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item'))
       .slice(0, 7)

--- a/packages/quill/src/ui/icon-picker.ts
+++ b/packages/quill/src/ui/icon-picker.ts
@@ -1,4 +1,7 @@
 import Picker from './picker.js';
+import { setTrustedInnerHtml } from '../core/utils/html.js';
+
+
 
 class IconPicker extends Picker {
   defaultItem: HTMLElement | null;
@@ -8,7 +11,10 @@ class IconPicker extends Picker {
     this.container.classList.add('ql-icon-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item')).forEach(
       (item) => {
-        item.innerHTML = icons[item.getAttribute('data-value') || ''];
+        setTrustedInnerHtml(
+          item as HTMLElement,
+          icons[item.getAttribute('data-value') || ''],
+        );
       },
     );
     this.defaultItem = this.container.querySelector('.ql-selected');
@@ -20,7 +26,7 @@ class IconPicker extends Picker {
     const item = target || this.defaultItem;
     if (item != null) {
       if (this.label.innerHTML === item.innerHTML) return;
-      this.label.innerHTML = item.innerHTML;
+      setTrustedInnerHtml(this.label, item.innerHTML);
     }
   }
 }

--- a/packages/quill/src/ui/icon-picker.ts
+++ b/packages/quill/src/ui/icon-picker.ts
@@ -1,6 +1,6 @@
 import Picker from './picker.js';
 import { setElementInnerHtml } from 'safevalues/dom';
-import { sanitizeHtml } from 'safevalues';
+import { htmlSafeByReview } from 'safevalues/restricted/reviewed';
 
 
 
@@ -14,7 +14,7 @@ class IconPicker extends Picker {
       (item) => {
         setElementInnerHtml(
           item as HTMLElement,
-          sanitizeHtml(icons[item.getAttribute('data-value') || '']),
+          htmlSafeByReview(icons[item.getAttribute('data-value') || ''], { justification: 'Bundled SVG icon' }),
         );
       },
     );
@@ -27,7 +27,7 @@ class IconPicker extends Picker {
     const item = target || this.defaultItem;
     if (item != null) {
       if (this.label.innerHTML === item.innerHTML) return;
-      setElementInnerHtml(this.label, sanitizeHtml(item.innerHTML));
+      setElementInnerHtml(this.label, htmlSafeByReview(item.innerHTML, { justification: 'Copied from trusted icon item' }));
     }
   }
 }

--- a/packages/quill/src/ui/icon-picker.ts
+++ b/packages/quill/src/ui/icon-picker.ts
@@ -1,5 +1,6 @@
 import Picker from './picker.js';
-import { setTrustedInnerHtml } from '../core/utils/html.js';
+import { setElementInnerHtml } from 'safevalues/dom';
+import { sanitizeHtml } from 'safevalues';
 
 
 
@@ -11,9 +12,9 @@ class IconPicker extends Picker {
     this.container.classList.add('ql-icon-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item')).forEach(
       (item) => {
-        setTrustedInnerHtml(
+        setElementInnerHtml(
           item as HTMLElement,
-          icons[item.getAttribute('data-value') || ''],
+          sanitizeHtml(icons[item.getAttribute('data-value') || '']),
         );
       },
     );
@@ -26,7 +27,7 @@ class IconPicker extends Picker {
     const item = target || this.defaultItem;
     if (item != null) {
       if (this.label.innerHTML === item.innerHTML) return;
-      setTrustedInnerHtml(this.label, item.innerHTML);
+      setElementInnerHtml(this.label, sanitizeHtml(item.innerHTML));
     }
   }
 }

--- a/packages/quill/src/ui/picker.ts
+++ b/packages/quill/src/ui/picker.ts
@@ -1,5 +1,6 @@
 import DropdownIcon from '../assets/icons/dropdown.svg';
-import { setTrustedInnerHtml } from '../core/utils/html.js';
+import { setElementInnerHtml } from 'safevalues/dom';
+import { sanitizeHtml } from 'safevalues';
 
 let optionsCounter = 0;
 
@@ -87,7 +88,7 @@ class Picker {
   buildLabel() {
     const label = document.createElement('span');
     label.classList.add('ql-picker-label');
-    setTrustedInnerHtml(label, DropdownIcon);
+    setElementInnerHtml(label, sanitizeHtml(DropdownIcon));
     // @ts-expect-error
     label.tabIndex = '0';
     label.setAttribute('role', 'button');

--- a/packages/quill/src/ui/picker.ts
+++ b/packages/quill/src/ui/picker.ts
@@ -1,4 +1,5 @@
 import DropdownIcon from '../assets/icons/dropdown.svg';
+import { setTrustedInnerHtml } from '../core/utils/html.js';
 
 let optionsCounter = 0;
 
@@ -8,6 +9,8 @@ function toggleAriaAttribute(element: HTMLElement, attribute: string) {
     `${!(element.getAttribute(attribute) === 'true')}`,
   );
 }
+
+
 
 class Picker {
   select: HTMLSelectElement;
@@ -84,7 +87,7 @@ class Picker {
   buildLabel() {
     const label = document.createElement('span');
     label.classList.add('ql-picker-label');
-    label.innerHTML = DropdownIcon;
+    setTrustedInnerHtml(label, DropdownIcon);
     // @ts-expect-error
     label.tabIndex = '0';
     label.setAttribute('role', 'button');

--- a/packages/quill/src/ui/picker.ts
+++ b/packages/quill/src/ui/picker.ts
@@ -1,6 +1,6 @@
 import DropdownIcon from '../assets/icons/dropdown.svg';
 import { setElementInnerHtml } from 'safevalues/dom';
-import { sanitizeHtml } from 'safevalues';
+import { htmlSafeByReview } from 'safevalues/restricted/reviewed';
 
 let optionsCounter = 0;
 
@@ -88,7 +88,7 @@ class Picker {
   buildLabel() {
     const label = document.createElement('span');
     label.classList.add('ql-picker-label');
-    setElementInnerHtml(label, sanitizeHtml(DropdownIcon));
+    setElementInnerHtml(label, htmlSafeByReview(DropdownIcon, { justification: 'Bundled SVG icon' }));
     // @ts-expect-error
     label.tabIndex = '0';
     label.setAttribute('role', 'button');

--- a/packages/quill/test/unit/formats/image.spec.ts
+++ b/packages/quill/test/unit/formats/image.spec.ts
@@ -1,0 +1,53 @@
+import Delta from 'quill-delta';
+import {
+  createScroll as baseCreateScroll,
+  createRegistry,
+} from '../__helpers__/factory.js';
+import Editor from '../../../src/core/editor.js';
+import Image from '../../../src/formats/image.js';
+import { describe, expect, test } from 'vitest';
+
+const createScroll = (html: string) =>
+  baseCreateScroll(html, createRegistry([Image]));
+
+describe('Image', () => {
+  test('add', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    editor.insertEmbed(1, 'image', 'https://quilljs.com/assets/favicon.png');
+    expect(editor.getDelta()).toEqual(
+      new Delta()
+        .insert('0')
+        .insert({ image: 'https://quilljs.com/assets/favicon.png' })
+        .insert('123\n'),
+    );
+    expect(editor.scroll.domNode).toEqualHTML(
+      '<p>0<img src="https://quilljs.com/assets/favicon.png">123</p>',
+    );
+  });
+
+  test('add invalid', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    editor.insertEmbed(1, 'image', 'javascript:alert(0);'); // eslint-disable-line no-script-url
+    expect(editor.getDelta()).toEqual(
+      new Delta()
+        .insert('0')
+        .insert({ image: '//:0' })
+        .insert('123\n'),
+    );
+    expect(editor.scroll.domNode).toEqualHTML(
+      '<p>0<img src="//:0">123</p>',
+    );
+  });
+
+  test('add data url', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    editor.insertEmbed(1, 'image', dataUrl);
+    expect(editor.getDelta()).toEqual(
+      new Delta()
+        .insert('0')
+        .insert({ image: dataUrl })
+        .insert('123\n'),
+    );
+  });
+});

--- a/packages/quill/test/unit/formats/video.spec.ts
+++ b/packages/quill/test/unit/formats/video.spec.ts
@@ -1,0 +1,37 @@
+import Delta from 'quill-delta';
+import {
+  createScroll as baseCreateScroll,
+  createRegistry,
+} from '../__helpers__/factory.js';
+import Editor from '../../../src/core/editor.js';
+import Video from '../../../src/formats/video.js';
+import { describe, expect, test } from 'vitest';
+
+const createScroll = (html: string) =>
+  baseCreateScroll(html, createRegistry([Video]));
+
+describe('Video', () => {
+  test('add', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    editor.insertEmbed(1, 'video', 'https://www.youtube.com/embed/QHH3iSeDBLo');
+    expect(editor.getDelta()).toEqual(
+      new Delta()
+        .insert('0')
+        .insert({ video: 'https://www.youtube.com/embed/QHH3iSeDBLo' })
+        .insert('123\n'),
+    );
+    // BlockEmbed might insert a new line or behave differently than inline embed
+    // Let's check the HTML structure
+  });
+
+  test('add invalid', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    editor.insertEmbed(1, 'video', 'javascript:alert(0);'); // eslint-disable-line no-script-url
+    expect(editor.getDelta()).toEqual(
+      new Delta()
+        .insert('0')
+        .insert({ video: 'about:blank' })
+        .insert('123\n'),
+    );
+  });
+});


### PR DESCRIPTION
This PR adds Trusted Types support to Quill to make it easier to run in strict security environments.

Changes:
- Added a centralized Trusted Types policy helper.
- Fixed `innerHTML` and `parseFromString` violations.
- Switched to `safevalues` for sanitizing links and images instead of custom stuff.
- Used `htmlSafeByReview` for the built-in SVG icons so they don't get stripped but stay secure.
- Cleaned up some `innerHTML = ''` usages.

Caveats:
- The `Video` format (`iframe.src`) is not updated to use `safevalues` as it requires `TrustedResourceUrl` which is difficult to apply generically without knowing the specific domains beforehand. It continues to use standard `setAttribute` with existing sanitization.

Passes existing tests.